### PR TITLE
refactor(styled): Migrate to transient props and extract shared CSS

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,4 +1,3 @@
-import { StyleSheetManager } from "styled-components";
 import { StyledButton } from "./styled";
 import { useState } from "react";
 
@@ -8,28 +7,22 @@ import Text from "../Text";
 function Button(props: any) {
 	const [isHovered, setIsHovered] = useState(false);
 
-	const filteredProps: string[] = ["isHovered", "p", "m", "url"];
-
 	return (
-		<StyleSheetManager
-			shouldForwardProp={(prop) => !filteredProps.includes(prop)}
+		<StyledButton
+			onMouseEnter={() => setIsHovered(true)}
+			onMouseLeave={() => setIsHovered(false)}
+			href={props.url}
+			target="_blank"
+			rel="noopener noreferrer"
+			$isHovered={isHovered}
+			$p={props.p}
+			$m={props.m}
 		>
-			<StyledButton
-				onMouseEnter={() => setIsHovered(true)}
-				onMouseLeave={() => setIsHovered(false)}
-				href={props.url}
-				target="_blank"
-				rel="noopener noreferrer"
-				isHovered={isHovered}
-				p={props.p}
-				m={props.m}
-			>
-				<Text variant={"details-fst"} alignment={"center"}>
-					{props.title}
-				</Text>
-				{props.children}
-			</StyledButton>
-		</StyleSheetManager>
+			<Text variant={"details-fst"} alignment={"center"}>
+				{props.title}
+			</Text>
+			{props.children}
+		</StyledButton>
 	);
 }
 

--- a/src/components/Button/styled.tsx
+++ b/src/components/Button/styled.tsx
@@ -5,9 +5,9 @@ import { StyledIconFrame } from "../IconFrame/styled";
 import { StyledText } from "../Text/styled";
 
 export const StyledButton = styled.a<{
-	isHovered: boolean;
-	m: string[];
-	p: string[];
+	$isHovered: boolean;
+	$m: string[];
+	$p: string[];
 }>`
 	width: auto;
 	height: 36px;
@@ -15,11 +15,11 @@ export const StyledButton = styled.a<{
 	justify-content: center;
 	align-items: center;
 	margin: ${(props) =>
-		props.m != null &&
-		props.m.map((marginSize) => `var(--${marginSize})`).join(" ")};
+		props.$m != null &&
+		props.$m.map((marginSize) => `var(--${marginSize})`).join(" ")};
 	padding: ${(props) =>
-		props.p != null &&
-		props.p.map((paddingSize) => `var(--${paddingSize})`).join(" ")};
+		props.$p != null &&
+		props.$p.map((paddingSize) => `var(--${paddingSize})`).join(" ")};
 	opacity: 0.4;
 	background-color: transparent;
 	border: 1px solid var(--text);
@@ -29,16 +29,16 @@ export const StyledButton = styled.a<{
 	z-index: 10;
 
 	&:hover {
-		opacity: 1;	
+		opacity: 1;
 		background-color: var(--accent);
 		border: 1px solid var(--primary);
-		
+
 		${StyledText} {
 			font-weight: 500;
 			color: var(--text-dark);
 		}
 	}
-	
+
 	&:active {
 		background-color: var(--primary);
 		transition: all 100ms;

--- a/src/components/Containers/About.tsx
+++ b/src/components/Containers/About.tsx
@@ -327,25 +327,25 @@ export default function About() {
 						gap={"20px"}
 					>
 						<Text
-							variant={"paragraph desktop"}
+							variant={"paragraph-desktop"}
 							alignment={"left"}
 						>
 							I’m Fache, a Fullstack Developer with +3 years collaborating with design and development teams to create high-impact digital experiences.
 						</Text>
 						<Text
-							variant={"paragraph desktop"}
+							variant={"paragraph-desktop"}
 							alignment={"left"}
 						>
 							Currently working with TypeScript, Next.js, and PostgreSQL, always exploring new and improved techniques and tools.
 						</Text>
 						<Text
-							variant={"paragraph desktop"}
+							variant={"paragraph-desktop"}
 							alignment={"left"}
 						>
 							Passionate about building applications that not only solve problems but also deliver smooth and engaging user experiences.
 						</Text>
 						<Text
-							variant={"paragraph desktop"}
+							variant={"paragraph-desktop"}
 							alignment={"left"}
 						>
 							I've been part of teams dedicated to developing high-quality, high-performance, and adaptable products.
@@ -378,25 +378,25 @@ export default function About() {
 						gap={"20px"}
 					>
 						<Text
-							variant={"paragraph desktop"}
+							variant={"paragraph-desktop"}
 							alignment={"left"}
 						>
 							I’m Fache, a Fullstack Developer with +3 years collaborating with design and development teams to create high-impact digital experiences.
 						</Text>
 						<Text
-							variant={"paragraph desktop"}
+							variant={"paragraph-desktop"}
 							alignment={"left"}
 						>
 							Currently working with TypeScript, Next.js, and PostgreSQL, always exploring new and improved techniques and tools.
 						</Text>
 						<Text
-							variant={"paragraph desktop"}
+							variant={"paragraph-desktop"}
 							alignment={"left"}
 						>
 							Passionate about building applications that not only solve problems but also deliver smooth and engaging user experiences.
 						</Text>
 						<Text
-							variant={"paragraph desktop"}
+							variant={"paragraph-desktop"}
 							alignment={"left"}
 						>
 							I've been part of teams dedicated to developing high-quality, high-performance, and adaptable products.

--- a/src/components/Containers/Container.tsx
+++ b/src/components/Containers/Container.tsx
@@ -1,83 +1,62 @@
 import styled from "styled-components";
-import { StyleSheetManager } from "styled-components";
 
 const StyledContainer = styled.div<{
-	style: string;
-	w: string;
-	minW: string;
-	maxW: string;
-	h: string;
-	minH: string;
-	maxH: string;
-	m: string[];
-	p: string[];
-	direction: string;
-	justify: string;
-	align: string;
-	gap: string;
-	wrap: string;
+	$css: string;
+	$w: string;
+	$minW: string;
+	$maxW: string;
+	$h: string;
+	$minH: string;
+	$maxH: string;
+	$m: string[];
+	$p: string[];
+	$direction: string;
+	$justify: string;
+	$align: string;
+	$gap: string;
+	$wrap: string;
 }>`
-	${(props) => props.style}
-	width: ${(props) => (props.w == null ? "100%" : props.w)};
-	min-width: ${(props) => (props.minW == null ? "" : props.minW)};
-	max-width: ${(props) => (props.maxW == null ? "" : props.maxW)};
-	height: ${(props) => (props.h == null ? "100%" : props.h)};
-	min-height: ${(props) => (props.minH == null ? "" : props.minH)};
-	max-height: ${(props) => (props.maxH == null ? "" : props.maxH)};
+	${(props) => props.$css}
+	width: ${(props) => (props.$w == null ? "100%" : props.$w)};
+	min-width: ${(props) => (props.$minW == null ? "" : props.$minW)};
+	max-width: ${(props) => (props.$maxW == null ? "" : props.$maxW)};
+	height: ${(props) => (props.$h == null ? "100%" : props.$h)};
+	min-height: ${(props) => (props.$minH == null ? "" : props.$minH)};
+	max-height: ${(props) => (props.$maxH == null ? "" : props.$maxH)};
 	display: flex;
 	margin: ${(props) =>
-		props.m &&
-		props.m.map((marginSize) => `var(--${marginSize})`).join(" ")};
+		props.$m &&
+		props.$m.map((marginSize) => `var(--${marginSize})`).join(" ")};
 	padding: ${(props) =>
-		props.p &&
-		props.p.map((paddingSize) => `var(--${paddingSize})`).join(" ")};
-	flex-direction: ${(props) => props.direction != null && props.direction};
-	flex-wrap: ${(props) => props.wrap != null && props.wrap};
-	justify-content: ${(props) => props.justify != null && props.justify};
-	align-items: ${(props) => props.align != null && props.align};
-	gap: ${(props) => props.gap != null && props.gap};
+		props.$p &&
+		props.$p.map((paddingSize) => `var(--${paddingSize})`).join(" ")};
+	flex-direction: ${(props) => props.$direction != null && props.$direction};
+	flex-wrap: ${(props) => props.$wrap != null && props.$wrap};
+	justify-content: ${(props) => props.$justify != null && props.$justify};
+	align-items: ${(props) => props.$align != null && props.$align};
+	gap: ${(props) => props.$gap != null && props.$gap};
 `;
 
 function Container(props: any) {
-	const filteredProps: string[] = [
-		"style",
-		"w",
-		"minW",
-		"maxW",
-		"h",
-		"minH",
-		"maxH",
-		"m",
-		"p",
-		"direction",
-		"justify",
-		"align",
-		"gap",
-		"wrap",
-	];
 	return (
-		<StyleSheetManager
-			shouldForwardProp={(prop) => !filteredProps.includes(prop)}
+		<StyledContainer
+			$css={props.$css}
+			$w={props.w}
+			$minW={props.minW}
+			$maxW={props.maxW}
+			$h={props.h}
+			$minH={props.minH}
+			$maxH={props.maxH}
+			$m={props.m}
+			$p={props.p}
+			$direction={props.direction}
+			$gap={props.gap}
+			$wrap={props.wrap}
+			$justify={props.justify}
+			$align={props.align}
 		>
-			<StyledContainer
-				style={props.style}
-				w={props.w}
-				minW={props.minW}
-				maxW={props.maxW}
-				h={props.h}
-				minH={props.minH}
-				maxH={props.maxH}
-				m={props.m}
-				p={props.p}
-				direction={props.direction}
-				gap={props.gap}
-				wrap={props.wrap}
-				justify={props.justify}
-				align={props.align}
-			>
-				{props.children}
-			</StyledContainer>
-		</StyleSheetManager>
+			{props.children}
+		</StyledContainer>
 	);
 }
 

--- a/src/components/Containers/Works.tsx
+++ b/src/components/Containers/Works.tsx
@@ -142,7 +142,7 @@ function Works(props: any) {
 						</Text>
 					</Container>
 					<Container
-						style={"overflow: hidden;"}
+						$css={"overflow: hidden;"}
 						w={"100vw"}
 						direction={"column"}
 						justify={"center"}
@@ -168,7 +168,7 @@ function Works(props: any) {
 					</Text>
 				</Container>
 				<Container
-					style={"overflow: hidden;"}
+					$css={"overflow: hidden;"}
 					minH={"402px"}
 					w={"56.4vw"}
 					direction={"row"}
@@ -194,7 +194,7 @@ function Works(props: any) {
 					</Text>
 				</Container>
 				<Container
-					style={"overflow: hidden;"}
+					$css={"overflow: hidden;"}
 					minH={"402px"}
 					w={"57.1vw"}
 					direction={"row"}
@@ -220,7 +220,7 @@ function Works(props: any) {
 					</Text>
 				</Container>
 				<Container
-					style={"overflow: hidden;"}
+					$css={"overflow: hidden;"}
 					minH={"402px"}
 					w={"57.55vw"}
 					direction={"row"}

--- a/src/components/ImageFrame/index.tsx
+++ b/src/components/ImageFrame/index.tsx
@@ -1,9 +1,6 @@
-import { StyleSheetManager } from "styled-components";
 import { StyledImageFrame } from "./styled";
 
 function ImageFrame(props: any) {
-	const filteredProps: string[] = ["p", "m", "src"];
-
 	const containerStyles = {
 		display: "flex",
 		alignItems: "center",
@@ -13,15 +10,11 @@ function ImageFrame(props: any) {
 	};
 
 	return (
-		<StyleSheetManager
-			shouldForwardProp={(prop) => !filteredProps.includes(prop)}
-		>
-			<div style={containerStyles}>
-				<StyledImageFrame p={props.p} m={props.m}>
-					<img src={props.src} alt={props.alt || ""} />
-				</StyledImageFrame>
-			</div>
-		</StyleSheetManager>
+		<div style={containerStyles}>
+			<StyledImageFrame $p={props.p} $m={props.m}>
+				<img src={props.src} alt={props.alt || ""} />
+			</StyledImageFrame>
+		</div>
 	);
 }
 

--- a/src/components/ImageFrame/styled.tsx
+++ b/src/components/ImageFrame/styled.tsx
@@ -1,17 +1,17 @@
 import styled from "styled-components";
 export const StyledImageFrame = styled.div<{
-	m: string[];
-	p: string[];
+	$m: string[];
+	$p: string[];
 }>`
 	//* Margin
 	margin: ${(props) =>
-		props.m &&
-		props.m.map((marginSize) => `var(--${marginSize})`).join(" ")};
+		props.$m &&
+		props.$m.map((marginSize) => `var(--${marginSize})`).join(" ")};
 
 	//* Padding
 	padding: ${(props) =>
-		props.p &&
-		props.p.map((paddingSize) => `var(--${paddingSize})`).join(" ")};
+		props.$p &&
+		props.$p.map((paddingSize) => `var(--${paddingSize})`).join(" ")};
 
 	@media (min-width: 360px) {
 		& {

--- a/src/components/Pill/index.tsx
+++ b/src/components/Pill/index.tsx
@@ -1,4 +1,3 @@
-import { StyleSheetManager } from "styled-components";
 import { StyledPillTag } from "./styled";
 
 //* Components
@@ -13,22 +12,17 @@ const tagSpinnerMap: Record<string, "braille" | "diagswipe" | "breathe"> = {
 };
 
 function PillTag(props: any) {
-	const filteredProps = ["isHovered", "maxW", "m", "p", "tag"];
 	const spinnerName = tagSpinnerMap[props.tag];
 
 	return (
-		<StyleSheetManager
-			shouldForwardProp={(prop) => !filteredProps.includes(prop)}
-		>
-			<StyledPillTag isHovered={props.isHovered} maxW={props.maxW} m={props.m} p={props.p}>
-				{spinnerName && (
-					<UnicodeSpinner name={spinnerName} style={{ fontSize: "10px" }} />
-				)}
-				<Text variant={"details-snd"} alignment={"center"}>
-					{props.tag}
-				</Text>
-			</StyledPillTag>
-		</StyleSheetManager>
+		<StyledPillTag $isHovered={props.isHovered} $maxW={props.maxW} $m={props.m} $p={props.p}>
+			{spinnerName && (
+				<UnicodeSpinner name={spinnerName} style={{ fontSize: "10px" }} />
+			)}
+			<Text variant={"details-snd"} alignment={"center"}>
+				{props.tag}
+			</Text>
+		</StyledPillTag>
 	);
 }
 

--- a/src/components/Pill/styled.tsx
+++ b/src/components/Pill/styled.tsx
@@ -1,25 +1,25 @@
 import styled from "styled-components";
 
 export const StyledPillTag = styled.span<{
-	isHovered: boolean;
-	maxW: string;
-	m: string[];
-	p: string[];
+	$isHovered: boolean;
+	$maxW: string;
+	$m: string[];
+	$p: string[];
 }>`
 	width: auto;
-	max-width: ${(props) => (props.maxW == null ? "130px" : props.maxW)};
+	max-width: ${(props) => (props.$maxW == null ? "130px" : props.$maxW)};
 	height: 22px;
 	display: flex;
 	justify-content: center;
 	align-items: center;
 	gap: 4px;
 	margin: ${(props) =>
-		props.m &&
-		props.m.map((marginSize) => `var(--${marginSize})`).join(" ")};
+		props.$m &&
+		props.$m.map((marginSize) => `var(--${marginSize})`).join(" ")};
 
 	padding: ${(props) =>
-		props.p &&
-		props.p.map((paddingSize) => `var(--${paddingSize})`).join(" ")};
+		props.$p &&
+		props.$p.map((paddingSize) => `var(--${paddingSize})`).join(" ")};
 	border: 1px solid var(--text);
 	border-radius: 30px;
 	transition: all 0.3s;

--- a/src/components/ProjectCard/index.tsx
+++ b/src/components/ProjectCard/index.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { StyleSheetManager } from 'styled-components';
 import { StyledProjectCard } from './styled';
 
 //* Components
@@ -11,16 +10,6 @@ import UnicodeSpinner from '../UnicodeSpinner';
 function ProjectCard(props: any) {
 	const [isHovered, setIsHovered] = useState(false);
 	const [imageLoaded, setImageLoaded] = useState(false);
-
-	const filteredProps: string[] = [
-		'isHovered',
-		'variant',
-		'title',
-		'details',
-		'tag',
-		'src',
-		'url',
-	];
 
 	useEffect(() => {
 		if (!props.src) return;
@@ -34,41 +23,37 @@ function ProjectCard(props: any) {
 	}, [props.src]);
 
 	return (
-		<StyleSheetManager
-			shouldForwardProp={(prop) => !filteredProps.includes(prop)}
+		<StyledProjectCard
+			className={"project-card"}
+			href={props.url}
+			target="_blank"
+			rel="noopener noreferrer"
+			onMouseEnter={() => setIsHovered(true)}
+			onMouseLeave={() => setIsHovered(false)}
+			$isHovered={isHovered}
 		>
-			<StyledProjectCard
-				className={"project-card"}
-				href={props.url}
-				target="_blank"
-				rel="noopener noreferrer"
-				onMouseEnter={() => setIsHovered(true)}
-				onMouseLeave={() => setIsHovered(false)}
-				isHovered={isHovered}
-			>
-				<Container direction={'column'} justify={'space-between'} align={'start'}>
-					<Text variant={'subtitle-fst'}>
-						{props.title}
-					</Text>
-					<Text variant={'details-fst'}>
-						{props.details}
-					</Text>
-					<PillTag
-						tag={props.tag}
-						maxW={'140px'}
-						p={['4', '8', '4', '6']}
-					/>
-				</Container>
-				<Container direction={'column'} justify={'center'} align={'end'}>
-					{!imageLoaded && <UnicodeSpinner name="pulse" />}
-					<img
-						src={props.src}
-						alt={`${props.title} logo`}
-						style={{ opacity: imageLoaded ? undefined : 0, position: imageLoaded ? undefined : 'absolute' }}
-					/>
-				</Container>
-			</StyledProjectCard>
-		</StyleSheetManager>
+			<Container direction={'column'} justify={'space-between'} align={'start'}>
+				<Text variant={'subtitle-fst'}>
+					{props.title}
+				</Text>
+				<Text variant={'details-fst'}>
+					{props.details}
+				</Text>
+				<PillTag
+					tag={props.tag}
+					maxW={'140px'}
+					p={['4', '8', '4', '6']}
+				/>
+			</Container>
+			<Container direction={'column'} justify={'center'} align={'end'}>
+				{!imageLoaded && <UnicodeSpinner name="pulse" />}
+				<img
+					src={props.src}
+					alt={`${props.title} logo`}
+					style={{ opacity: imageLoaded ? undefined : 0, position: imageLoaded ? undefined : 'absolute' }}
+				/>
+			</Container>
+		</StyledProjectCard>
 	);
 }
 

--- a/src/components/ProjectCard/styled.tsx
+++ b/src/components/ProjectCard/styled.tsx
@@ -1,10 +1,8 @@
 import styled from 'styled-components';
-
-//* Components
-import { StyledPillTag } from '../Pill/styled';
+import { glassCard, hoveredPillStyles } from '../../styles/mixins';
 
 export const StyledProjectCard = styled.a<{
-	isHovered: boolean;
+	$isHovered: boolean;
 }>`
 	text-decoration: none;
 	color: inherit;
@@ -15,43 +13,7 @@ export const StyledProjectCard = styled.a<{
 	justify-content: space-between;
 	align-items: center;
 	padding: 10px;
-	background-color: rgba(197, 199, 188, 5%);
-	background-clip: padding-box;
-	border: 1px solid transparent;
-	/* box-shadow: 0px -1px 0px 0px rgba(255, 255, 255, 0.2),
-		-1px 0px 0px 0px rgba(255, 255, 255, 0.1),
-		1px 0px 0px 0px rgba(255, 255, 255, 0.1); */
-	border-radius: 20px;
-	backdrop-filter: blur(4px);
-	cursor: pointer;
-	transition: all 300ms;
-
-	&::before {
-		content: '';
-		position: absolute;
-		inset: 0;
-		border-radius: 20px;
-		padding: 1px;
-		background: linear-gradient(
-			to bottom,
-			rgba(197, 199, 188, 10%),
-			rgba(197, 199, 188, 0%)
-		);
-		mask: linear-gradient(#f2e8ea 0 0) content-box, linear-gradient(#f2e8ea 0 0);
-		-webkit-mask: linear-gradient(#f2e8ea 0 0) content-box,
-			linear-gradient(#f2e8ea 0 0);
-		-webkit-mask-composite: xor;
-		mask-composite: exclude;
-		transition: all 300ms;
-	}
-
-	&:hover::before {
-		background: linear-gradient(
-			to bottom,
-			rgba(197, 199, 188, 30%),
-			rgba(197, 199, 188, 6%)
-		);
-	}
+	${glassCard}
 
 	@media (max-width: 768px) {
 		& {
@@ -66,17 +28,9 @@ export const StyledProjectCard = styled.a<{
 	}
 
 	& img {
-		opacity: ${(props) => (props.isHovered ? '1' : '0.6')};
+		opacity: ${(props) => (props.$isHovered ? '1' : '0.6')};
 		transition: all 300ms;
 	}
 
-	${StyledPillTag} {
-		color: ${(props) =>
-		props.isHovered ? "var(--pill-text-hovered)" : "var(--text)"};
-		background-color: ${(props) =>
-		props.isHovered ? "var(--accent)" : "transparent"};
-			border-color: ${(props) =>
-		props.isHovered ? "var(--primary)" : "inherit"};
-		opacity: ${(props) => (props.isHovered ? "1" : "0.6")};
-	}
+	${(props) => hoveredPillStyles(props.$isHovered)}
 `;

--- a/src/components/SocialButton/index.tsx
+++ b/src/components/SocialButton/index.tsx
@@ -1,23 +1,16 @@
-import { StyleSheetManager } from "styled-components";
 import { StyledSocialButton } from "./styled";
 
 function SocialButton(props: any) {
-	const filteredProps: string[] = ["src", "url", "alt"];
-
 	return (
-		<StyleSheetManager
-			shouldForwardProp={(prop) => !filteredProps.includes(prop)}
+		<StyledSocialButton
+			className={"button"}
+			href={props.url}
+			target="_blank"
+			rel="noopener noreferrer"
+			aria-label={props.alt}
 		>
-			<StyledSocialButton
-				className={"button"}
-				href={props.url}
-				target="_blank"
-				rel="noopener noreferrer"
-				aria-label={props.alt}
-			>
-				<img src={props.src} alt={props.alt || ""} />
-			</StyledSocialButton>
-		</StyleSheetManager>
+			<img src={props.src} alt={props.alt || ""} />
+		</StyledSocialButton>
 	);
 }
 

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -1,30 +1,17 @@
-import { StyleSheetManager } from "styled-components";
 import { StyledText } from "./styled";
 
 export default function Text(props: any) {
-	const filteredProps: string[] = [
-		"w",
-		"h",
-		"m",
-		"p",
-		"variant",
-		"alignment",
-	];
 	return (
-		<StyleSheetManager
-			shouldForwardProp={(prop) => !filteredProps.includes(prop)}
+		<StyledText
+			as={props.as}
+			$w={props.w}
+			$h={props.h}
+			$m={props.m}
+			$p={props.p}
+			$variant={props.variant}
+			$alignment={props.alignment}
 		>
-			<StyledText
-				as={props.as}
-				w={props.w}
-				h={props.h}
-				m={props.m}
-				p={props.p}
-				variant={props.variant}
-				alignment={props.alignment}
-			>
-				{props.children}
-			</StyledText>
-		</StyleSheetManager>
+			{props.children}
+		</StyledText>
 	);
 }

--- a/src/components/Text/styled.tsx
+++ b/src/components/Text/styled.tsx
@@ -1,23 +1,23 @@
 import styled from 'styled-components';
 export const StyledText = styled.p<{
-	w: string;
-	h: string;
-	m: string[];
-	p: string[];
-	variant: string;
-	alignment: string;
+	$w: string;
+	$h: string;
+	$m: string[];
+	$p: string[];
+	$variant: string;
+	$alignment: string;
 }>`
-	width: ${(props) => props.w};
-	height: ${(props) => props.h};
+	width: ${(props) => props.$w};
+	height: ${(props) => props.$h};
 	margin: ${(props) =>
-		props.m && props.m.map((marginSize) => `var(--${marginSize})`).join(' ')};
+		props.$m && props.$m.map((marginSize) => `var(--${marginSize})`).join(' ')};
 	padding: ${(props) =>
-		props.p && props.p.map((paddingSize) => `var(--${paddingSize})`).join(' ')};
-	text-align: ${(props) => props.alignment !== null && props.alignment};
+		props.$p && props.$p.map((paddingSize) => `var(--${paddingSize})`).join(' ')};
+	text-align: ${(props) => props.$alignment !== null && props.$alignment};
 	font-family: var(--font-geist-pixel-grid);
 
 	${(props) =>
-		props.variant === 'title' &&
+		props.$variant === 'title' &&
 		`
 			font-size: 40px;
 			line-height: 40px;
@@ -26,7 +26,7 @@ export const StyledText = styled.p<{
 	`}
 
 	${(props) =>
-		props.variant === 'subtitle-fst' &&
+		props.$variant === 'subtitle-fst' &&
 		`
 			font-size: 30px;
 			line-height: 30px;
@@ -35,7 +35,7 @@ export const StyledText = styled.p<{
 	`}
 
 ${(props) =>
-		props.variant === 'subtitle-fst desktop' &&
+		props.$variant === 'subtitle-fst-desktop' &&
 		`
 			font-size: 40px;
 			line-height: 40px;
@@ -44,7 +44,7 @@ ${(props) =>
 	`}
 
 	${(props) =>
-		props.variant === 'subtitle-snd' &&
+		props.$variant === 'subtitle-snd' &&
 		`
 			font-size: 18px;
 			line-height: 18px;
@@ -53,7 +53,7 @@ ${(props) =>
 	`}
 
 ${(props) =>
-		props.variant === 'paragraph' &&
+		props.$variant === 'paragraph' &&
 		`
 			font-size: 16px;
 			font-weight: 500;
@@ -63,7 +63,7 @@ ${(props) =>
 	`}
 
 	${(props) =>
-		props.variant === 'paragraph work-card' &&
+		props.$variant === 'paragraph-work-card' &&
 		`
 			font-size: 14px;
 			font-weight: 500;
@@ -73,7 +73,7 @@ ${(props) =>
 	`}
 
 ${(props) =>
-		props.variant === 'paragraph desktop' &&
+		props.$variant === 'paragraph-desktop' &&
 		`
 			text-align: start;
 			font-weight: 500;
@@ -97,7 +97,7 @@ ${(props) =>
 	`}
 
 	${(props) =>
-		props.variant === 'details-fst' &&
+		props.$variant === 'details-fst' &&
 		`
 			line-height: 15px;
 			font-size: 12px;
@@ -108,7 +108,7 @@ ${(props) =>
 	`}
 
 	${(props) =>
-		props.variant === 'details-snd' &&
+		props.$variant === 'details-snd' &&
 		`
 			line-height: 10px;
 			font-size: 10px;

--- a/src/components/WorkCard/index.tsx
+++ b/src/components/WorkCard/index.tsx
@@ -1,4 +1,3 @@
-import { StyleSheetManager } from 'styled-components';
 import { StyledWorkCard } from './styled';
 import { useState } from 'react';
 
@@ -15,103 +14,86 @@ import IconFrame from '../IconFrame';
 function WorkCard(props: any) {
 	const [isHovered, setIsHovered] = useState(false);
 
-	const filteredProps: string[] = [
-		'isHovered',
-		'p',
-		'm',
-		'variant',
-		'title',
-		'tags',
-		'details',
-		'showcaseUrl',
-		'url',
-		'src',
-	];
-
 	return (
-		<StyleSheetManager
-			shouldForwardProp={(prop) => !filteredProps.includes(prop)}
+		<StyledWorkCard
+			className={"work-card"}
+			href={props.url}
+			target="_blank"
+			rel="noopener noreferrer"
+			onMouseEnter={() => setIsHovered(true)}
+			onMouseLeave={() => setIsHovered(false)}
+			$isHovered={isHovered}
+			$p={props.p}
+			$m={props.m}
 		>
-			<StyledWorkCard
-				className={"work-card"}
-				href={props.url}
-				target="_blank"
-				rel="noopener noreferrer"
-				onMouseEnter={() => setIsHovered(true)}
-				onMouseLeave={() => setIsHovered(false)}
-				isHovered={isHovered}
-				p={props.p}
-				m={props.m}
+			<Container
+				w={'60%'}
+				h={'100%'}
+				direction={'column'}
+				justify={'space-between'}
+				align={'start'}
 			>
 				<Container
-					w={'60%'}
+					w={'100%'}
 					h={'100%'}
 					direction={'column'}
 					justify={'space-between'}
 					align={'start'}
+					gap={"20px"}
 				>
+					<Text variant={'title'}>
+						{props.title}
+					</Text>
+					<Container
+						w={'100%'}
+						h={'auto'}
+						direction={'row'}
+						gap={"6px"}
+					>
+						{props.tags.map((tag: any) => {
+							return (
+								<PillTag
+									key={tag}
+									tag={tag}
+									p={['4', '8', '4', '8']}
+								/>
+							);
+						})}
+					</Container>
+					<Text
+						w={'90%'}
+						variant={'paragraph-work-card'}
+						alignment={'start'}
+					>
+						{props.details}
+					</Text>
 					<Container
 						w={'100%'}
 						h={'100%'}
 						direction={'column'}
-						justify={'space-between'}
+						justify={'flex-end'}
 						align={'start'}
-						gap={"20px"}
 					>
-						<Text variant={'title'}>
-							{props.title}
-						</Text>
-						<Container
-							w={'100%'}
-							h={'auto'}
-							direction={'row'}
-							gap={"6px"}
-						>
-							{props.tags.map((tag: any) => {
-								return (
-									<PillTag
-										key={tag}
-										tag={tag}
-										p={['4', '8', '4', '8']}
-									/>
-								);
-							})}
-						</Container>
-						<Text
-							w={'90%'}
-							variant={'paragraph work-card'}
-							alignment={'start'}
-						>
-							{props.details}
-						</Text>
-						<Container
-							w={'100%'}
-							h={'100%'}
-							direction={'column'}
-							justify={'flex-end'}
-							align={'start'}
-						>
 
-							<Button
-								title={'Visit page'}
-								p={['0', '2', '0', '8']}
-								url={props.url}
-							>
-								<IconFrame src={arrowIcon} />
-							</Button>
-						</Container>
+						<Button
+							title={'Visit page'}
+							p={['0', '2', '0', '8']}
+							url={props.url}
+						>
+							<IconFrame src={arrowIcon} />
+						</Button>
 					</Container>
 				</Container>
-				<Container
-					w={'40%'}
-					direction={'column'}
-					justify={'center'}
-					align={'end'}
-				>
-					<img className="work-logo" src={props.src} alt={`${props.title} logo`} />
-				</Container>
-			</StyledWorkCard>
-		</StyleSheetManager >
+			</Container>
+			<Container
+				w={'40%'}
+				direction={'column'}
+				justify={'center'}
+				align={'end'}
+			>
+				<img className="work-logo" src={props.src} alt={`${props.title} logo`} />
+			</Container>
+		</StyledWorkCard>
 	);
 }
 

--- a/src/components/WorkCard/styled.tsx
+++ b/src/components/WorkCard/styled.tsx
@@ -1,12 +1,10 @@
 import styled from "styled-components";
-
-//* Components
-import { StyledPillTag } from "../Pill/styled";
+import { glassCard, hoveredPillStyles } from "../../styles/mixins";
 
 export const StyledWorkCard = styled.a<{
-	isHovered: boolean;
-	m: string[];
-	p: string[];
+	$isHovered: boolean;
+	$m: string[];
+	$p: string[];
 }>`
 	text-decoration: none;
 	color: inherit;
@@ -16,41 +14,8 @@ export const StyledWorkCard = styled.a<{
 	justify-content: space-between;
 	align-items: center;
 	padding: 10px;
-	background-color: rgba(197, 199, 188, 5%);
-	background-clip: padding-box;
-	border: 1px solid transparent;
-	border-radius: 20px;
-	backdrop-filter: blur(4px);
-	cursor: pointer;
 	overflow: hidden;
-	transition: all 300ms;
-
-	&::before {
-		content: "";
-		position: absolute;
-		inset: 0;
-		border-radius: 20px;
-		padding: 1px;
-		background: linear-gradient(
-			to bottom,
-			rgba(197, 199, 188, 10%),
-			rgba(197, 199, 188, 0%)
-		);
-		mask: linear-gradient(#f2e8ea 0 0) content-box, linear-gradient(#f2e8ea 0 0);
-		-webkit-mask: linear-gradient(#f2e8ea 0 0) content-box,
-			linear-gradient(#f2e8ea 0 0);
-		-webkit-mask-composite: xor;
-		mask-composite: exclude;
-		transition: all 300ms;
-	}
-
-	&:hover::before {
-		background: linear-gradient(
-			to bottom,
-			rgba(197, 199, 188, 30%),
-			rgba(197, 199, 188, 6%)
-		);
-	}
+	${glassCard}
 
 	@media (min-width: 375px) {
 		& {
@@ -71,18 +36,10 @@ export const StyledWorkCard = styled.a<{
 		left: 180px;
 		width: auto;
 		height: 190px;
-		opacity: ${(props) => (props.isHovered ? "1" : "0.2")};
+		opacity: ${(props) => (props.$isHovered ? "1" : "0.2")};
 		transition: all 300ms;
 		z-index: -1;
 	}
 
-	${StyledPillTag} {
-		color: ${(props) =>
-		props.isHovered ? "var(--pill-text-hovered)" : "var(--text)"};
-		background-color: ${(props) =>
-		props.isHovered ? "var(--accent)" : "transparent"};
-			border-color: ${(props) =>
-		props.isHovered ? "var(--primary)" : "inherit"};
-		opacity: ${(props) => (props.isHovered ? "1" : "0.6")};
-	}
+	${(props) => hoveredPillStyles(props.$isHovered)}
 `;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -65,14 +65,14 @@ function Home() {
 						h={'100%'}
 						justify={'center'}
 						align={'center'}
-						style={'border-top: 1px solid var(--secondary-60);'}
+						$css={'border-top: 1px solid var(--secondary-60);'}
 					>
 						<Container
 							w={'90%'}
 							h={"100%"}
 							justify={'center'}
 							align={'center'}
-							style={`
+							$css={`
 								border-left: 1px solid var(--secondary-60);
 								border-right: 1px solid var(--secondary-60);
 								`}
@@ -89,7 +89,7 @@ function Home() {
 					minH={"462px"}
 					justify={'center'}
 					align={'start'}
-					style={'border-top: 1px solid var(--secondary-60);'}
+					$css={'border-top: 1px solid var(--secondary-60);'}
 				>
 					<Container w={'90%'} h={"100%"} justify={'center'} align={'center'}>
 						<Skills flex={1} />
@@ -111,14 +111,14 @@ function Home() {
 						w={'100%'}
 						justify={'center'}
 						align={'center'}
-						style={'border-top: 1px solid var(--secondary-60);'}
+						$css={'border-top: 1px solid var(--secondary-60);'}
 					>
 						<Container
 							w={'90%'}
 							h={"100%"}
 							justify={'center'}
 							align={'center'}
-							style={`
+							$css={`
 								border-left: 1px solid var(--secondary-60);
 								border-right: 1px solid var(--secondary-60);
 								`}
@@ -134,7 +134,7 @@ function Home() {
 					h={'55vh'}
 					minH={"510px"}
 					justify={'center'}
-					style={'border-top: 1px solid var(--secondary-60);'}
+					$css={'border-top: 1px solid var(--secondary-60);'}
 				>
 					<Container w={'90%'} justify={'center'} align={'center'}>
 						<Skills flex={1} />
@@ -156,14 +156,14 @@ function Home() {
 						h={'100%'}
 						justify={'center'}
 						align={'center'}
-						style={'border-top: 1px solid var(--secondary-60);'}
+						$css={'border-top: 1px solid var(--secondary-60);'}
 					>
 						<Container
 							w={'90%'}
 							h={"fit-content"}
 							justify={'center'}
 							align={'center'}
-							style={`
+							$css={`
 								border-left: 1px solid var(--secondary-60);
 								border-right: 1px solid var(--secondary-60);
 								`}
@@ -181,7 +181,7 @@ function Home() {
 					minH={"530px"}
 					justify={'center'}
 					align={'start'}
-					style={'border-top: 1px solid var(--secondary-60);'}
+					$css={'border-top: 1px solid var(--secondary-60);'}
 				>
 					<Container w={'90%'} justify={'center'} align={'center'}>
 						<Skills flex={1} />

--- a/src/styles/mixins.ts
+++ b/src/styles/mixins.ts
@@ -1,0 +1,67 @@
+import { css } from 'styled-components';
+import { StyledPillTag } from '../components/Pill/styled';
+
+export const glassCard = css`
+	background-color: rgba(197, 199, 188, 5%);
+	background-clip: padding-box;
+	border: 1px solid transparent;
+	border-radius: 20px;
+	backdrop-filter: blur(4px);
+	cursor: pointer;
+	transition: all 300ms;
+
+	&::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		border-radius: 20px;
+		padding: 1px;
+		background: linear-gradient(
+			to bottom,
+			rgba(197, 199, 188, 10%),
+			rgba(197, 199, 188, 0%)
+		);
+		mask: linear-gradient(#f2e8ea 0 0) content-box, linear-gradient(#f2e8ea 0 0);
+		-webkit-mask: linear-gradient(#f2e8ea 0 0) content-box,
+			linear-gradient(#f2e8ea 0 0);
+		-webkit-mask-composite: xor;
+		mask-composite: exclude;
+		transition: all 300ms;
+	}
+
+	&:hover::before {
+		background: linear-gradient(
+			to bottom,
+			rgba(197, 199, 188, 30%),
+			rgba(197, 199, 188, 6%)
+		);
+	}
+`;
+
+export const hoveredPillStyles = (isHovered: boolean) => css`
+	${StyledPillTag} {
+		color: ${isHovered ? "var(--pill-text-hovered)" : "var(--text)"};
+		background-color: ${isHovered ? "var(--accent)" : "transparent"};
+		border-color: ${isHovered ? "var(--primary)" : "inherit"};
+		opacity: ${isHovered ? "1" : "0.6"};
+	}
+`;
+
+export const interactiveHover = css`
+	opacity: 0.6;
+	transition: all 150ms;
+
+	&:hover {
+		opacity: 1;
+		background-color: var(--accent);
+		border: 1px solid var(--primary);
+	}
+
+	&:active {
+		background-color: var(--primary);
+		transition: all 100ms;
+	}
+`;
+
+export const spacingArray = (values: string[] | undefined) =>
+	values ? values.map((v) => `var(--${v})`).join(' ') : undefined;


### PR DESCRIPTION
## Summary
- Replace `StyleSheetManager` wrappers with transient props (`$` prefix) in 9 components (-116 lines net)
- Extract shared CSS to `src/styles/mixins.ts` (glassCard, hoveredPillStyles, interactiveHover, spacingArray)
- Normalize Text variant names: spaces → hyphens (`"paragraph work-card"` → `"paragraph-work-card"`, etc.)
- Rename Container `style` prop to `$css` to avoid React collision

## Test plan
- [ ] `npm run build` passes without errors
- [ ] Visual regression check: all components render identically
- [ ] WorkCard and ProjectCard glass-morphism effect works on hover
- [ ] Text variants display correctly across all breakpoints
- [ ] Container borders in desktop layout render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)