### PR TITLE
refactor(types): Add TypeScript interfaces to all components

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -4,7 +4,10 @@ import { useState } from "react";
 //* Components
 import Text from "../Text";
 
-function Button(props: any) {
+//? Types
+import { ButtonProps } from "../../types";
+
+function Button(props: ButtonProps) {
 	const [isHovered, setIsHovered] = useState(false);
 
 	return (

--- a/src/components/Button/styled.tsx
+++ b/src/components/Button/styled.tsx
@@ -6,8 +6,8 @@ import { StyledText } from "../Text/styled";
 
 export const StyledButton = styled.a<{
 	$isHovered: boolean;
-	$m: string[];
-	$p: string[];
+	$m?: string[];
+	$p?: string[];
 }>`
 	width: auto;
 	height: 36px;

--- a/src/components/Containers/Container.tsx
+++ b/src/components/Containers/Container.tsx
@@ -1,20 +1,21 @@
 import styled from "styled-components";
+import { ContainerProps } from "../../types";
 
 const StyledContainer = styled.div<{
-	$css: string;
-	$w: string;
-	$minW: string;
-	$maxW: string;
-	$h: string;
-	$minH: string;
-	$maxH: string;
-	$m: string[];
-	$p: string[];
-	$direction: string;
-	$justify: string;
-	$align: string;
-	$gap: string;
-	$wrap: string;
+	$css?: string;
+	$w?: string;
+	$minW?: string;
+	$maxW?: string;
+	$h?: string;
+	$minH?: string;
+	$maxH?: string;
+	$m?: string[];
+	$p?: string[];
+	$direction?: string;
+	$justify?: string;
+	$align?: string;
+	$gap?: string;
+	$wrap?: string;
 }>`
 	${(props) => props.$css}
 	width: ${(props) => (props.$w == null ? "100%" : props.$w)};
@@ -37,7 +38,7 @@ const StyledContainer = styled.div<{
 	gap: ${(props) => props.$gap != null && props.$gap};
 `;
 
-function Container(props: any) {
+function Container(props: ContainerProps) {
 	return (
 		<StyledContainer
 			$css={props.$css}

--- a/src/components/Containers/Skills.tsx
+++ b/src/components/Containers/Skills.tsx
@@ -5,6 +5,9 @@ import MediaQuery from "react-responsive";
 import Container from "./Container";
 import Text from "../Text";
 
+//? Types
+import { SectionProps } from "../../types";
+
 //* Assets
 import BashIcon from "../../assets/icons/Bash.svg";
 import TSIcon from "../../assets/icons/TypeScript.svg";
@@ -28,7 +31,7 @@ import FramerIcon from "../../assets/icons/Framer.svg";
 import AISDKIcon from "../../assets/icons/AISDK.svg";
 
 const StyledSkills = styled.section<{
-	flex: number;
+	flex?: number;
 }>`
 	width: 100%;;
 	height: 100%;
@@ -59,7 +62,7 @@ const StyledIcon = styled.img`
 	opacity: 0.8;
 `;
 
-function Skills(props: any) {
+function Skills(props: SectionProps) {
 	return (
 		<StyledSkills flex={props.flex}>
 			<MediaQuery minWidth={360} maxWidth={767}>

--- a/src/components/Containers/Works.tsx
+++ b/src/components/Containers/Works.tsx
@@ -6,11 +6,14 @@ import Container from "./Container";
 import WorkCardsCarousel from "../WorkCardsCarousel";
 import Text from "../Text";
 
+//? Types
+import { SectionProps } from "../../types";
+
 //* Assets
 import patternVector from "../../assets/vectors/pattern-vector.svg";
 
 const StyledWorks = styled.section<{
-	flex: number;
+	flex?: number;
 }>`
 	height: 100%;
 	display: flex;
@@ -50,7 +53,7 @@ const StyledWorks = styled.section<{
 	}
 `;
 
-function Works(props: any) {
+function Works(props: SectionProps) {
 	return (
 		<StyledWorks flex={props.flex}>
 			<MediaQuery minWidth={360} maxWidth={767}>

--- a/src/components/Cursor/index.tsx
+++ b/src/components/Cursor/index.tsx
@@ -12,7 +12,7 @@ import styles from "./styles.module.css"
 export default function Cursor() {
 
   const cursorRef = useRef<SVGSVGElement | null>(null);
-  const mouseRef = useRef<any>({ x: null, y: null, });
+  const mouseRef = useRef<{ x: gsap.QuickToFunc | null; y: gsap.QuickToFunc | null }>({ x: null, y: null });
 
   const [isMobileDevice, setIsMobileDevice] = useState(false);
 
@@ -45,8 +45,8 @@ export default function Cursor() {
     };
 
     const onMouseMove = (e: MouseEvent) => {
-      mouseRef.current.x(e.clientX);
-      mouseRef.current.y(e.clientY);
+      mouseRef.current.x?.(e.clientX);
+      mouseRef.current.y?.(e.clientY);
     };
 
     const onMouseOver = (e: MouseEvent) => {

--- a/src/components/IconFrame/index.tsx
+++ b/src/components/IconFrame/index.tsx
@@ -1,6 +1,7 @@
 import { StyledIconFrame } from "./styled";
+import { IconFrameProps } from "../../types";
 
-function IconFrame(props: any) {
+function IconFrame(props: IconFrameProps) {
 	return <StyledIconFrame src={props.src} alt={props.alt || ""} />;
 }
 

--- a/src/components/ImageFrame/index.tsx
+++ b/src/components/ImageFrame/index.tsx
@@ -1,6 +1,7 @@
 import { StyledImageFrame } from "./styled";
+import { ImageFrameProps } from "../../types";
 
-function ImageFrame(props: any) {
+function ImageFrame(props: ImageFrameProps) {
 	const containerStyles = {
 		display: "flex",
 		alignItems: "center",

--- a/src/components/ImageFrame/styled.tsx
+++ b/src/components/ImageFrame/styled.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 export const StyledImageFrame = styled.div<{
-	$m: string[];
-	$p: string[];
+	$m?: string[];
+	$p?: string[];
 }>`
 	//* Margin
 	margin: ${(props) =>

--- a/src/components/Pill/index.tsx
+++ b/src/components/Pill/index.tsx
@@ -4,6 +4,9 @@ import { StyledPillTag } from "./styled";
 import Text from "../Text";
 import UnicodeSpinner from "../UnicodeSpinner";
 
+//? Types
+import { PillProps } from "../../types";
+
 const tagSpinnerMap: Record<string, "braille" | "diagswipe" | "breathe"> = {
 	"Work in progress": "braille",
 	"V2.0": "diagswipe",
@@ -11,11 +14,11 @@ const tagSpinnerMap: Record<string, "braille" | "diagswipe" | "breathe"> = {
 	"Design": "breathe",
 };
 
-function PillTag(props: any) {
+function PillTag(props: PillProps) {
 	const spinnerName = tagSpinnerMap[props.tag];
 
 	return (
-		<StyledPillTag $isHovered={props.isHovered} $maxW={props.maxW} $m={props.m} $p={props.p}>
+		<StyledPillTag $maxW={props.maxW} $m={props.m} $p={props.p}>
 			{spinnerName && (
 				<UnicodeSpinner name={spinnerName} style={{ fontSize: "10px" }} />
 			)}

--- a/src/components/Pill/styled.tsx
+++ b/src/components/Pill/styled.tsx
@@ -1,10 +1,10 @@
 import styled from "styled-components";
 
 export const StyledPillTag = styled.span<{
-	$isHovered: boolean;
-	$maxW: string;
-	$m: string[];
-	$p: string[];
+	$isHovered?: boolean;
+	$maxW?: string;
+	$m?: string[];
+	$p?: string[];
 }>`
 	width: auto;
 	max-width: ${(props) => (props.$maxW == null ? "130px" : props.$maxW)};

--- a/src/components/ProjectCard/index.tsx
+++ b/src/components/ProjectCard/index.tsx
@@ -7,7 +7,10 @@ import Container from '../Containers/Container';
 import PillTag from '../Pill';
 import UnicodeSpinner from '../UnicodeSpinner';
 
-function ProjectCard(props: any) {
+//? Types
+import { ProjectCardProps } from '../../types';
+
+function ProjectCard(props: ProjectCardProps) {
 	const [isHovered, setIsHovered] = useState(false);
 	const [imageLoaded, setImageLoaded] = useState(false);
 

--- a/src/components/SocialButton/index.tsx
+++ b/src/components/SocialButton/index.tsx
@@ -1,6 +1,7 @@
 import { StyledSocialButton } from "./styled";
+import { SocialButtonProps } from "../../types";
 
-function SocialButton(props: any) {
+function SocialButton(props: SocialButtonProps) {
 	return (
 		<StyledSocialButton
 			className={"button"}

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -1,6 +1,7 @@
 import { StyledText } from "./styled";
+import { TextProps } from "../../types";
 
-export default function Text(props: any) {
+export default function Text(props: TextProps) {
 	return (
 		<StyledText
 			as={props.as}

--- a/src/components/WorkCard/index.tsx
+++ b/src/components/WorkCard/index.tsx
@@ -11,7 +11,10 @@ import PillTag from '../Pill';
 import Button from '../Button';
 import IconFrame from '../IconFrame';
 
-function WorkCard(props: any) {
+//? Types
+import { WorkCardProps } from '../../types';
+
+function WorkCard(props: WorkCardProps) {
 	const [isHovered, setIsHovered] = useState(false);
 
 	return (
@@ -50,7 +53,7 @@ function WorkCard(props: any) {
 						direction={'row'}
 						gap={"6px"}
 					>
-						{props.tags.map((tag: any) => {
+						{props.tags.map((tag: string) => {
 							return (
 								<PillTag
 									key={tag}

--- a/src/components/WorkCard/styled.tsx
+++ b/src/components/WorkCard/styled.tsx
@@ -3,8 +3,8 @@ import { glassCard, hoveredPillStyles } from "../../styles/mixins";
 
 export const StyledWorkCard = styled.a<{
 	$isHovered: boolean;
-	$m: string[];
-	$p: string[];
+	$m?: string[];
+	$p?: string[];
 }>`
 	text-decoration: none;
 	color: inherit;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,3 +7,91 @@ export type ThemeProviderProps = {
 export type ThemeContextType = {
 	isDarkMode: boolean;
 };
+
+export type ContainerProps = {
+	children?: ReactNode;
+	w?: string;
+	minW?: string;
+	maxW?: string;
+	h?: string;
+	minH?: string;
+	maxH?: string;
+	m?: string[];
+	p?: string[];
+	direction?: string;
+	justify?: string;
+	align?: string;
+	gap?: string;
+	wrap?: string;
+	display?: string;
+	$css?: string;
+	flex?: number;
+	ref?: React.Ref<HTMLDivElement>;
+};
+
+export type TextProps = {
+	children?: ReactNode;
+	as?: React.ElementType;
+	w?: string;
+	h?: string;
+	m?: string[];
+	p?: string[];
+	variant?: string;
+	alignment?: string;
+};
+
+export type WorkCardProps = {
+	title: string;
+	tags: string[];
+	details: string;
+	url: string;
+	showcaseUrl?: string;
+	src: string;
+	p?: string[];
+	m?: string[];
+};
+
+export type ProjectCardProps = {
+	title: string;
+	details: string;
+	tag: string;
+	url: string;
+	src: string;
+};
+
+export type ButtonProps = {
+	children?: ReactNode;
+	title: string;
+	url: string;
+	p?: string[];
+	m?: string[];
+};
+
+export type SocialButtonProps = {
+	url: string;
+	src: string;
+	alt?: string;
+};
+
+export type PillProps = {
+	tag: string;
+	maxW?: string;
+	m?: string[];
+	p?: string[];
+};
+
+export type IconFrameProps = {
+	src: string;
+	alt?: string;
+};
+
+export type ImageFrameProps = {
+	src: string;
+	alt?: string;
+	p?: string[];
+	m?: string[];
+};
+
+export type SectionProps = {
+	flex?: number;
+};


### PR DESCRIPTION
## Summary
- Define 10 TypeScript interfaces in `src/types/index.ts` (ContainerProps, TextProps, WorkCardProps, etc.)
- Replace `props: any` with typed interfaces in 11 components
- Type `mouseRef` in Cursor with `gsap.QuickToFunc` and add null safety via optional chaining
- Make styled-component transient props optional where needed

## Test plan
- [ ] `npm run build` passes without TypeScript errors
- [ ] All components render correctly with typed props

🤖 Generated with [Claude Code](https://claude.com/claude-code)