### PR TITLE
refactor(responsive): Config-driven layout replacing duplicated MediaQuery blocks

### DIFF
--- a/src/components/Containers/About.tsx
+++ b/src/components/Containers/About.tsx
@@ -1,11 +1,14 @@
 import styled from "styled-components";
-import MediaQuery from "react-responsive";
 
 //* Components
 import Container from "./Container";
 import Text from "../../components/Text";
 
-const StyledAbout = styled.section<{}>`
+//? Hooks & Config
+import { useBreakpoint } from "../../hooks/useBreakpoint";
+import { aboutConfig } from "../../config/responsive";
+
+const StyledAbout = styled.section`
 	width: 100%;
 	height: 100%;
 	display: flex;
@@ -15,395 +18,71 @@ const StyledAbout = styled.section<{}>`
 	padding: 0 20px;
 
 	@media (min-width: 1280px) {
-		& {			
+		& {
 			height: 100%;
 			border-right: 1px solid var(--secondary-60);
 		}
 	}
 `;
 
+const paragraphs = [
+	"I'm Fache, a Fullstack Developer with +3 years collaborating with design and development teams to create high-impact digital experiences.",
+	"Currently working with TypeScript, Next.js, and PostgreSQL, always exploring new and improved techniques and tools.",
+	"Passionate about building applications that not only solve problems but also deliver smooth and engaging user experiences.",
+	"I've been part of teams dedicated to developing high-quality, high-performance, and adaptable products.",
+];
+
 export default function About() {
+	const bp = useBreakpoint();
+	const cfg = aboutConfig[bp];
+
 	return (
 		<StyledAbout>
-			<MediaQuery minWidth={360} maxWidth={767}>
+			<Container
+				w={cfg.outerW}
+				maxW={cfg.outerMaxW}
+				h={cfg.outerH}
+				minH={cfg.outerMinH}
+				m={['36', '0', '36', '0']}
+				direction={"column"}
+				justify={"space-between"}
+				align={"center"}
+				gap={cfg.outerGap}
+			>
 				<Container
-					h={"100%"}
-					w={"100%"}
-					m={['36', '0', '36', '0']}
-					maxW={"500px"}
+					w={cfg.innerW}
+					h={"auto"}
+					direction={"column"}
+					justify={"center"}
+					align={"flex-start"}
+				>
+					<Text
+						as="h2"
+						variant={"subtitle-snd"}
+						alignment={cfg.titleAlign}
+					>
+						ABOUT ME
+					</Text>
+				</Container>
+				<Container
+					w={cfg.innerW}
+					display={"flex"}
 					direction={"column"}
 					justify={"space-between"}
-					align={"center"}
-					gap={"24px"}
+					align={"flex-start"}
+					gap={cfg.paragraphGap}
 				>
-					<Container
-						h={"auto"}
-						direction={"column"}
-						justify={"center"}
-						align={"start"}
-					>
+					{paragraphs.map((text) => (
 						<Text
-							as="h2"
-							variant={"subtitle-snd"}
-						>
-							ABOUT ME
-						</Text>
-					</Container>
-					<Container
-						display={"flex"}
-						direction={"column"}
-						justify={"space-between"}
-						align={"flex-start"}
-						gap={"12px"}
-					>
-						<Text
-							variant={"paragraph"}
+							key={text.slice(0, 20)}
+							variant={cfg.paragraphVariant}
 							alignment={"left"}
 						>
-							I’m Fache, a Fullstack Developer with +3 years collaborating with design and development teams to create high-impact digital experiences.
+							{text}
 						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							Currently working with TypeScript, Next.js, and PostgreSQL, always exploring new and improved techniques and tools.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							Passionate about building applications that not only solve problems but also deliver smooth and engaging user experiences.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							I've been part of teams dedicated to developing high-quality, high-performance, and adaptable products.
-						</Text>
-					</Container>
+					))}
 				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={768} maxWidth={959}>
-				<Container
-					w={"80%"}
-					m={['36', '0', '36', '0']}
-					direction={"column"}
-					justify={"space-between"}
-					align={"center"}
-					gap={"24px"}
-				>
-					<Container
-						h={"auto"}
-						direction={"column"}
-						justify={"center"}
-						align={"flex-start"}
-					>
-
-						<Text
-							as="h2"
-							variant={"subtitle-snd"}
-						>
-							ABOUT ME
-						</Text>
-					</Container>
-					<Container
-						display={"flex"}
-						direction={"column"}
-						justify={"space-between"}
-						align={"flex-start"}
-						gap={"12px"}
-					>
-
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-
-						>
-							I’m Fache, a Fullstack Developer with +3 years collaborating with design and development teams to create high-impact digital experiences.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-
-						>
-							Currently working with TypeScript, Next.js, and PostgreSQL, always exploring new and improved techniques and tools.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-
-						>
-							Passionate about building applications that not only solve problems but also deliver smooth and engaging user experiences.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-
-						>
-							I've been part of teams dedicated to developing high-quality, high-performance, and adaptable products.
-						</Text>
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={960} maxWidth={1279}>
-				<Container
-					w={"80%"}
-					m={['36', '0', '36', '0']}
-					direction={"column"}
-					justify={"space-between"}
-					align={"center"}
-					gap={"24px"}
-				>
-					<Container
-						h={"auto"}
-						direction={"column"}
-						justify={"center"}
-						align={"flex-start"}
-					>
-						<Text
-							as="h2"
-							variant={"subtitle-snd"}
-							alignment={"left"}
-						>
-							ABOUT ME
-						</Text>
-					</Container>
-					<Container
-						display={"flex"}
-						direction={"column"}
-						justify={"space-between"}
-						align={"flex-start"}
-						gap={"12px"}
-					>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							I’m Fache, a Fullstack Developer with +3 years collaborating with design and development teams to create high-impact digital experiences.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							Currently working with TypeScript, Next.js, and PostgreSQL, always exploring new and improved techniques and tools.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							Passionate about building applications that not only solve problems but also deliver smooth and engaging user experiences.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							I've been part of teams dedicated to developing high-quality, high-performance, and adaptable products.
-						</Text>
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={1280} maxWidth={1339}>
-				<Container
-					w={"100%"} h={"100%"} minH={"450px"} m={['36', '0', '36', '0']} direction={"column"} justify={"space-between"} align={"center"} gap={"36px"}>
-					<Container
-						h={"auto"}
-						direction={"column"}
-						justify={"center"}
-						align={"flex-start"}
-					>
-						<Text
-							as="h2"
-							variant={"subtitle-snd"}
-							alignment={"left"}
-						>
-							ABOUT ME
-						</Text>
-					</Container>
-					<Container
-						display={"flex"}
-						direction={"column"}
-						justify={"space-between"}
-						align={"flex-start"}
-						gap={"20px"}
-					>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							I’m Fache, a Fullstack Developer with +3 years collaborating with design and development teams to create high-impact digital experiences.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							Currently working with TypeScript, Next.js, and PostgreSQL, always exploring new and improved techniques and tools.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							Passionate about building applications that not only solve problems but also deliver smooth and engaging user experiences.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							I've been part of teams dedicated to developing high-quality, high-performance, and adaptable products.
-						</Text>
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={1340} maxWidth={1439}>
-				<Container w={"100%"} h={"100%"} minH={"450px"} m={['36', '0', '36', '0']} direction={"column"} justify={"space-between"} align={"center"} gap={"36px"}>
-					<Container
-						h={"auto"}
-						direction={"column"}
-						justify={"center"}
-						align={"flex-start"}
-					>
-						<Text
-							as="h2"
-							variant={"subtitle-snd"}
-						>
-							ABOUT ME
-						</Text>
-					</Container>
-					<Container
-						display={"flex"}
-						direction={"column"}
-						justify={"space-between"}
-						align={"flex-start"}
-						gap={"20px"}
-					>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							I’m Fache, a Fullstack Developer with +3 years collaborating with design and development teams to create high-impact digital experiences.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							Currently working with TypeScript, Next.js, and PostgreSQL, always exploring new and improved techniques and tools.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							Passionate about building applications that not only solve problems but also deliver smooth and engaging user experiences.
-						</Text>
-						<Text
-							variant={"paragraph"}
-							alignment={"left"}
-						>
-							I've been part of teams dedicated to developing high-quality, high-performance, and adaptable products.
-						</Text>
-					</Container>
-				</Container>
-			</MediaQuery>
-
-			<MediaQuery minWidth={1440} maxWidth={1800}>
-				<Container w={"100%"} h={"100%"} minH={"490px"} m={['36', '0', '36', '0']} direction={"column"} justify={"space-between"} align={"center"} gap={"36px"}>
-					<Container
-						w={"100%"}
-						h={"100%"}
-						direction={"column"}
-						justify={"space-between"}
-						align={"flex-start"}
-					>
-						<Text
-							as="h2"
-							variant={"subtitle-snd"}
-						>
-							ABOUT ME
-						</Text>
-					</Container>
-					<Container
-						display={"flex"}
-						direction={"column"}
-						justify={"space-between"}
-						align={"flex-start"}
-						gap={"20px"}
-					>
-						<Text
-							variant={"paragraph-desktop"}
-							alignment={"left"}
-						>
-							I’m Fache, a Fullstack Developer with +3 years collaborating with design and development teams to create high-impact digital experiences.
-						</Text>
-						<Text
-							variant={"paragraph-desktop"}
-							alignment={"left"}
-						>
-							Currently working with TypeScript, Next.js, and PostgreSQL, always exploring new and improved techniques and tools.
-						</Text>
-						<Text
-							variant={"paragraph-desktop"}
-							alignment={"left"}
-						>
-							Passionate about building applications that not only solve problems but also deliver smooth and engaging user experiences.
-						</Text>
-						<Text
-							variant={"paragraph-desktop"}
-							alignment={"left"}
-						>
-							I've been part of teams dedicated to developing high-quality, high-performance, and adaptable products.
-						</Text>
-
-					</Container>
-				</Container>
-			</MediaQuery>
-
-			<MediaQuery minWidth={1801}>
-				<Container w={"100%"} h={"100%"} minH={"530px"} m={['36', '0', '36', '0']} direction={"column"} justify={"space-between"} align={"center"} gap={"36px"}>
-
-					<Container
-						h={"auto"}
-						w={"80%"}
-						direction={"column"}
-						justify={"center"}
-						align={"flex-start"}
-					>
-						<Text as="h2" variant={"subtitle-snd"}>
-							ABOUT ME
-						</Text>
-					</Container>
-					<Container
-						w={"80%"}
-						display={"flex"}
-						direction={"column"}
-						justify={"space-between"}
-						align={"flex-start"}
-						gap={"20px"}
-					>
-						<Text
-							variant={"paragraph-desktop"}
-							alignment={"left"}
-						>
-							I’m Fache, a Fullstack Developer with +3 years collaborating with design and development teams to create high-impact digital experiences.
-						</Text>
-						<Text
-							variant={"paragraph-desktop"}
-							alignment={"left"}
-						>
-							Currently working with TypeScript, Next.js, and PostgreSQL, always exploring new and improved techniques and tools.
-						</Text>
-						<Text
-							variant={"paragraph-desktop"}
-							alignment={"left"}
-						>
-							Passionate about building applications that not only solve problems but also deliver smooth and engaging user experiences.
-						</Text>
-						<Text
-							variant={"paragraph-desktop"}
-							alignment={"left"}
-						>
-							I've been part of teams dedicated to developing high-quality, high-performance, and adaptable products.
-						</Text>
-					</Container>
-				</Container>
-			</MediaQuery>
+			</Container>
 		</StyledAbout>
 	);
 }

--- a/src/components/Containers/Projects.tsx
+++ b/src/components/Containers/Projects.tsx
@@ -1,16 +1,17 @@
 import styled from 'styled-components';
-import MediaQuery from 'react-responsive';
 
 //* Components
 import Container from '../../components/Containers/Container';
 import ProjectCard from '../../components/ProjectCard';
 import Text from '../../components/Text';
 
+//? Hooks, Config & Data
+import { useBreakpoint } from '../../hooks/useBreakpoint';
+import { projectsConfig } from '../../config/responsive';
+import { projects } from '../../data/projects';
+
 //* Assets
 import patternVector from '../../assets/vectors/pattern-vector.svg';
-import facheVector from '../../assets/vectors/fache.svg';
-import facheAIVector from '../../assets/vectors/facheai.svg';
-import centryBoardVector from '../../assets/vectors/centryboard.svg';
 
 const StyledProjects = styled.section`
 	width: 100%;
@@ -31,7 +32,7 @@ const StyledProjects = styled.section`
 			background-position: top right;
 		}
 	}
-	
+
 	@media (min-width: 1280px) {
 		& {
 			background-position: center;
@@ -43,245 +44,52 @@ const StyledProjects = styled.section`
 `;
 
 function Projects() {
+	const bp = useBreakpoint();
+	const cfg = projectsConfig[bp];
+
 	return (
 		<StyledProjects>
-			<MediaQuery minWidth={360} maxWidth={767}>
+			<Container
+				w={cfg.outerW}
+				maxW={cfg.outerMaxW}
+				h={cfg.outerH}
+				minH={cfg.outerMinH}
+				m={['36', '0', '36', '0']}
+				direction={"column"}
+				justify={cfg.outerJustify}
+				align={"center"}
+				gap={"36px"}
+			>
 				<Container
-					h={"80%"}
-					w={"100%"}
-					maxW={"500px"}
-					m={["36", "0", "36", "0"]}
-					direction={"column"}
-					justify={"center"}
-					align={"center"}
-					gap={"36px"}>
-
-					<Container w={'100%'} justify={'flex-start'} align={'center'}>
-						<Text as="h2" variant={'subtitle-snd'} >
-							PROJECTS
-						</Text>
-					</Container>
-					<Container direction={'column'} justify={'center'} align={'center'} gap={'12px'}>
-						<ProjectCard
-							title={'CentryBoard'}
-							details={'Productivity Booster App'}
-							tag={"Work in progress"}
-
-							src={centryBoardVector}
-							url={
-								'https://centryboard.site'
-							}
-						/>
-						<ProjectCard
-							title={'fache.ai'}
-							details={'AI Assistant App'}
-							tag={"Work in progress"}
-							src={facheAIVector}
-							url={'https://fache-ai-agent.vercel.app/'}
-						/>
-						<ProjectCard
-							title={'fache.'}
-							details={'Personal Website'}
-							tag={"V2.0"}
-							src={facheVector}
-							url={'https://fache.vercel.app'}
-						/>
-					</Container>
+					h={cfg.titleH}
+					w={'100%'}
+					justify={cfg.titleJustify}
+					align={'center'}
+				>
+					<Text as="h2" variant={'subtitle-snd'}>
+						PROJECTS
+					</Text>
 				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={768} maxWidth={959}>
-				<Container h={"80%"}
-					w={"80%"}
-					m={["36", "0", "36", "0"]}
-					direction={"column"}
-					justify={"center"}
-					align={"center"}
-					gap={"36px"}>
-					<Container h={'100%'} w={'100%'} justify={'flex-start'} align={'center'}>
-						<Text as="h2" variant={'subtitle-snd'}>
-							PROJECTS
-						</Text>
-					</Container>
-					<Container direction={'column'} justify={'center'} align={'center'} gap={'12px'}>
+				<Container
+					h={bp.startsWith('desktop') ? '100%' : undefined}
+					direction={'column'}
+					justify={bp.startsWith('desktop') ? 'center' : 'center'}
+					align={'center'}
+					gap={cfg.cardGap}
+				>
+					{projects.map((project) => (
 						<ProjectCard
-							title={'CentryBoard'}
-							details={'Productivity Booster App'}
-							tag={"Work in progress"}
-
-							src={centryBoardVector}
-							url={
-								'https://centryboard.site'
-							}
+							key={project.title}
+							title={project.title}
+							details={project.details}
+							tag={project.tag}
+							src={project.src}
+							url={project.url}
 						/>
-						<ProjectCard
-							title={'fache.ai'}
-							details={'AI Assistant App'}
-							tag={"Work in progress"}
-							src={facheAIVector}
-							url={'https://fache-ai-agent.vercel.app/'}
-						/>
-						<ProjectCard
-							title={'fache.'}
-							details={'Personal Website'}
-							tag={"V2.0"}
-							src={facheVector}
-							url={'https://fache.vercel.app'}
-						/>
-					</Container>
+					))}
 				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={960} maxWidth={1279}>
-				<Container h={"100%"}
-					w={"80%"}
-					m={["36", "0", "36", "0"]}
-					direction={"column"}
-					justify={"center"}
-					align={"center"}
-					gap={"36px"}>
-					<Container h={'100%'} w={'100%'} justify={'flex-start'} align={'center'}>
-						<Text as="h2" variant={'subtitle-snd'}>
-							PROJECTS
-						</Text>
-					</Container>
-					<Container direction={'column'} justify={'center'} align={'center'} gap={"12px"}>
-						<ProjectCard
-							title={'CentryBoard'}
-							details={'Productivity Booster App'}
-							tag={"Work in progress"}
-
-							src={centryBoardVector}
-							url={
-								'https://centryboard.site'
-							}
-						/>
-						<ProjectCard
-							title={'fache.ai'}
-							details={'AI Assistant App'}
-							tag={"Work in progress"}
-							src={facheAIVector}
-							url={'https://fache-ai-agent.vercel.app/'}
-						/>
-						<ProjectCard
-							title={'fache.'}
-							details={'Personal Website'}
-							tag={"V2.0"}
-							src={facheVector}
-							url={'https://fache.vercel.app'}
-						/>
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={1280} maxWidth={1439}>
-				<Container w={"100%"} h={"100%"} minH={"450px"} m={['36', '0', '36', '0']} direction={"column"} justify={"space-between"} align={"center"} gap={"36px"}>
-					<Container h={'100%'} w={'100%'} justify={'space-between'} align={'center'} >
-						<Text as="h2" variant={'subtitle-snd'}>
-							PROJECTS
-						</Text>
-					</Container>
-					<Container h={"100%"} direction={'column'} justify={'center'} align={'center'} gap={"20px"}>
-						<ProjectCard
-							title={'CentryBoard'}
-							details={'Productivity Booster App'}
-							tag={"Work in progress"}
-
-							src={centryBoardVector}
-							url={
-								'https://centryboard.site'
-							}
-						/>
-						<ProjectCard
-							title={'fache.ai'}
-							details={'AI Assistant App'}
-							tag={"Work in progress"}
-							src={facheAIVector}
-							url={'https://fache-ai-agent.vercel.app/'}
-						/>
-						<ProjectCard
-							title={'fache.'}
-							details={'Personal Website'}
-							tag={"V2.0"}
-							src={facheVector}
-							url={'https://fache.vercel.app'}
-						/>
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={1440} maxWidth={1800}>
-				<Container w={"100%"} h={"100%"} minH={"490px"} m={['36', '0', '36', '0']} direction={"column"} justify={"space-between"} align={"center"} gap={"36px"}>
-					<Container w={'100%'} h={'100%'} justify={'space-between'} align={'center'} >
-						<Text as="h2" variant={'subtitle-snd'}>
-							PROJECTS
-						</Text>
-					</Container>
-					<Container
-						h={"100%"}
-						direction={'column'}
-						justify={'space-between'}
-						align={'center'}
-						gap={"20px"}
-					>
-						<ProjectCard
-							title={'CentryBoard'}
-							details={'Productivity Booster App'}
-							tag={"Work in progress"}
-
-							src={centryBoardVector}
-							url={
-								'https://centryboard.site'
-							}
-						/>
-						<ProjectCard
-							title={'fache.ai'}
-							details={'AI Assistant App'}
-							tag={"Work in progress"}
-							src={facheAIVector}
-							url={'https://fache-ai-agent.vercel.app/'}
-						/>
-						<ProjectCard
-							title={'fache.'}
-							details={'Personal Website'}
-							tag={"V2.0"}
-							src={facheVector}
-							url={'https://fache.vercel.app'}
-						/>
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={1801}>
-				<Container w={"75%"} h={"100%"} minH={"530px"} m={['36', '0', '36', '0']} direction={"column"} justify={"space-between"} align={"center"} gap={"36px"}>
-					<Container h={"auto"} w={'100%'} justify={'flex-start'} align={'center'}>
-						<Text as="h2" variant={'subtitle-snd'}>
-							PROJECTS
-						</Text>
-					</Container>
-					<Container h={"max-content"} direction={'column'} justify={'center'} align={'center'} gap={"20px"}>
-						<ProjectCard
-							title={'CentryBoard'}
-							details={'Productivity Booster App'}
-							tag={"Work in progress"}
-							src={centryBoardVector}
-							url={
-								'https://centryboard.site/'
-							}
-						/>
-						<ProjectCard
-							title={'fache.ai'}
-							details={'AI Assistant App'}
-							tag={"Work in progress"}
-							src={facheAIVector}
-							url={'https://fache-ai-agent.vercel.app/'}
-						/>
-						<ProjectCard
-							title={'fache.'}
-							details={'Personal Website'}
-							tag={"V2.0"}
-							src={facheVector}
-							url={'https://fache.vercel.app'}
-						/>
-					</Container>
-				</Container>
-			</MediaQuery>
-		</StyledProjects >
+			</Container>
+		</StyledProjects>
 	);
 }
 

--- a/src/components/Containers/Skills.tsx
+++ b/src/components/Containers/Skills.tsx
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import MediaQuery from "react-responsive";
 
 //* Components
 import Container from "./Container";
@@ -8,32 +7,15 @@ import Text from "../Text";
 //? Types
 import { SectionProps } from "../../types";
 
-//* Assets
-import BashIcon from "../../assets/icons/Bash.svg";
-import TSIcon from "../../assets/icons/TypeScript.svg";
-import NodeJSIcon from "../../assets/icons/NodeJS.svg";
-import JSIcon from "../../assets/icons/JavaScript.svg";
-import CSSIcon from "../../assets/icons/CSS.svg";
-import WCIcon from "../../assets/icons/WebComponents.svg";
-import ReactJSIcon from "../../assets/icons/ReactJS.svg";
-import NextJSIcon from "../../assets/icons/NextJS.svg";
-import ExpressJSIcon from "../../assets/icons/ExpressJS.svg";
-import PostmanIcon from "../../assets/icons/Postman.svg";
-import FirebaseIcon from "../../assets/icons/Firebase.svg";
-import PostgreSQLIcon from "../../assets/icons/PostgreSQL.svg";
-import SequelizeJSIcon from "../../assets/icons/SequelizeJS.svg";
-import PrismaIcon from "../../assets/icons/Prisma.svg";
-import GitIcon from "../../assets/icons/Git.svg";
-import ThreeJSIcon from "../../assets/icons/ThreeJS.svg";
-import FramerMotionIcon from "../../assets/icons/FramerMotion.svg";
-import FigmaIcon from "../../assets/icons/Figma.svg";
-import FramerIcon from "../../assets/icons/Framer.svg";
-import AISDKIcon from "../../assets/icons/AISDK.svg";
+//? Hooks, Config & Data
+import { useBreakpoint } from "../../hooks/useBreakpoint";
+import { skillsConfig } from "../../config/responsive";
+import { skillRows } from "../../data/skills";
 
 const StyledSkills = styled.section<{
 	flex?: number;
 }>`
-	width: 100%;;
+	width: 100%;
 	height: 100%;
 	padding: 0 20px;
 	display: flex;
@@ -63,409 +45,85 @@ const StyledIcon = styled.img`
 `;
 
 function Skills(props: SectionProps) {
-	return (
-		<StyledSkills flex={props.flex}>
-			<MediaQuery minWidth={360} maxWidth={767}>
-				<Container
-					w={"100%"}
-					maxW={"500px"}
-					h={"70%"}
-					m={["36", "0", "36", "0"]}
-					direction={"column"}
-					justify={"center"}
-					align={"center"}
-					gap={"36px"}
-				>
-					<Container
-						w={"100%"}
-						h={"100%"}
-						justify={"flex-start"}
-						align={"center"}
-					>
-						<Text as="h2" variant={"subtitle-snd"} alignment={"center"}>
-							SKILLS & TOOLS
-						</Text>
-					</Container>
-					<Container
-						justify={"space-between"}
-						align={"center"}
-					>
-						<StyledIcon src={BashIcon} title="Bash" alt="Bash" />
-						<StyledIcon src={NodeJSIcon} title="Node.js" alt="Node.js" />
-						<StyledIcon src={JSIcon} title="JavaScript" alt="JavaScript" />
-						<StyledIcon src={TSIcon} title="TypeScript" alt="TypeScript" />
-					</Container>
-					<Container
-						justify={"space-between"}
-						align={"center"}
-					>
-						<StyledIcon src={CSSIcon} title="CSS" alt="CSS" />
-						<StyledIcon src={WCIcon} title="Web Components" alt="Web Components" />
-						<StyledIcon src={ReactJSIcon} title="React.js" alt="React.js" />
-						<StyledIcon src={NextJSIcon} title="Next.js" alt="Next.js" />
-					</Container>
-					<Container justify={"space-between"} align={"center"}>
-						<StyledIcon src={ExpressJSIcon} title="Express.js" alt="Express.js" />
-						<StyledIcon src={PostmanIcon} title="Postman" alt="Postman" />
-						<StyledIcon src={FirebaseIcon} title="Firebase" alt="Firebase" />
-						<StyledIcon src={PostgreSQLIcon} title="PostgreSQL" alt="PostgreSQL" />
-					</Container>
-					<Container justify={"space-between"} align={"center"}>
-						<StyledIcon src={SequelizeJSIcon} title="Sequelize" alt="Sequelize" />
-						<StyledIcon src={PrismaIcon} title="Prisma" alt="Prisma" />
-						<StyledIcon src={GitIcon} title="Git" alt="Git" />
-						<StyledIcon src={ThreeJSIcon} title="Three.js" alt="Three.js" />
-					</Container>
-					<Container justify={"space-between"} align={"center"}>
-						<StyledIcon src={FramerMotionIcon} title="Framer Motion" alt="Framer Motion" />
-						<StyledIcon src={FigmaIcon} title="Figma" alt="Figma" />
-						<StyledIcon src={FramerIcon} title="Framer" alt="Framer" />
-						<StyledIcon src={AISDKIcon} title="AI SDK" alt="AI SDK" />
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={768} maxWidth={959}>
-				<Container
-					w={"80%"}
-					h={"70%"}
-					m={["36", "0", "36", "0"]}
-					direction={"column"}
-					justify={"center"}
-					align={"center"}
-					gap={"36px"}
-				>
-					<Container
-						w={"100%"}
-						h={"100%"}
-						justify={"flex-start"}
-						align={"center"}
-					>
+	const bp = useBreakpoint();
+	const cfg = skillsConfig[bp];
 
-						<Text as="h2" variant={"subtitle-snd"}>
-							SKILLS & TOOLS
-						</Text>
-					</Container>
-					<Container
-						h={"70%"}
-						direction={"column"}
-						justify={"center"}
-						align={"center"}
-						gap={"24px"}
-					>
-						<Container
-							w={"100%"}
-							justify={"space-evenly"}
-							align={"center"}
-						>
-							<StyledIcon src={BashIcon} title="Bash" alt="Bash" />
-							<StyledIcon src={NodeJSIcon} title="Node.js" alt="Node.js" />
-							<StyledIcon src={JSIcon} title="JavaScript" alt="JavaScript" />
-							<StyledIcon src={TSIcon} title="TypeScript" alt="TypeScript" />
-						</Container>
-						<Container
-							w={"100%"}
-							justify={"space-evenly"}
-							align={"center"}
-						>
-							<StyledIcon src={CSSIcon} title="CSS" alt="CSS" />
-							<StyledIcon src={WCIcon} title="Web Components" alt="Web Components" />
-							<StyledIcon src={ReactJSIcon} title="React.js" alt="React.js" />
-							<StyledIcon src={NextJSIcon} title="Next.js" alt="Next.js" />
-						</Container>
-						<Container
-							w={"100%"}
-							justify={"space-evenly"}
-							align={"center"}
-						>
-							<StyledIcon src={ExpressJSIcon} title="Express.js" alt="Express.js" />
-							<StyledIcon src={PostmanIcon} title="Postman" alt="Postman" />
-							<StyledIcon src={FirebaseIcon} title="Firebase" alt="Firebase" />
-							<StyledIcon src={PostgreSQLIcon} title="PostgreSQL" alt="PostgreSQL" />
-						</Container>
-						<Container
-							w={"100%"}
-							justify={"space-evenly"}
-							align={"center"}
-						>
-							<StyledIcon src={SequelizeJSIcon} title="Sequelize" alt="Sequelize" />
-							<StyledIcon src={PrismaIcon} title="Prisma" alt="Prisma" />
-							<StyledIcon src={GitIcon} title="Git" alt="Git" />
-							<StyledIcon src={ThreeJSIcon} title="Three.js" alt="Three.js" />
-						</Container>
-						<Container
-							w={"100%"}
-							justify={"space-evenly"}
-							align={"center"}
-						>
-							<StyledIcon src={FramerMotionIcon} title="Framer Motion" alt="Framer Motion" />
-							<StyledIcon src={FigmaIcon} title="Figma" alt="Figma" />
-							<StyledIcon src={FramerIcon} title="Framer" alt="Framer" />
-							<StyledIcon src={AISDKIcon} title="AI SDK" alt="AI SDK" />
-						</Container>
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={960} maxWidth={1279}>
-				<Container
-					w={"80%"}
-					h={"100%"}
-					m={["36", "0", "36", "0"]}
-					direction={"column"}
-					justify={"center"}
-					align={"center"}
-					gap={"36px"}
-				>
-					<Container
-						w={"100%"}
-						h={"100%"}
-						justify={"flex-start"}
-						align={"center"}
-					>
-						<Text as="h2" variant={"subtitle-snd"} >
-							SKILLS & TOOLS
-						</Text>
-					</Container>
-					<Container
-						h={"70%"}
-						direction={"column"}
-						justify={"center"}
-						align={"center"}
-						gap={"24px"}
-					>
-						<Container
-							w={"70%"}
-							justify={"space-evenly"}
-							align={"center"}
-						>
-							<StyledIcon src={BashIcon} title="Bash" alt="Bash" />
-							<StyledIcon src={NodeJSIcon} title="Node.js" alt="Node.js" />
-							<StyledIcon src={JSIcon} title="JavaScript" alt="JavaScript" />
-							<StyledIcon src={TSIcon} title="TypeScript" alt="TypeScript" />
-						</Container>
-						<Container
-							w={"70%"}
-							justify={"space-evenly"}
-							align={"center"}
-						>
-							<StyledIcon src={CSSIcon} title="CSS" alt="CSS" />
-							<StyledIcon src={WCIcon} title="Web Components" alt="Web Components" />
-							<StyledIcon src={ReactJSIcon} title="React.js" alt="React.js" />
-							<StyledIcon src={NextJSIcon} title="Next.js" alt="Next.js" />
-						</Container>
-						<Container
-							w={"70%"}
-							justify={"space-evenly"}
-							align={"center"}
-						>
-							<StyledIcon src={ExpressJSIcon} title="Express.js" alt="Express.js" />
-							<StyledIcon src={PostmanIcon} title="Postman" alt="Postman" />
-							<StyledIcon src={FirebaseIcon} title="Firebase" alt="Firebase" />
-							<StyledIcon src={PostgreSQLIcon} title="PostgreSQL" alt="PostgreSQL" />
-						</Container>
-						<Container
-							w={"70%"}
-							justify={"space-evenly"}
-							align={"center"}
-						>
-							<StyledIcon src={SequelizeJSIcon} title="Sequelize" alt="Sequelize" />
-							<StyledIcon src={PrismaIcon} title="Prisma" alt="Prisma" />
-							<StyledIcon src={GitIcon} title="Git" alt="Git" />
-							<StyledIcon src={ThreeJSIcon} title="Three.js" alt="Three.js" />
-						</Container>
-						<Container
-							w={"70%"}
-							justify={"space-evenly"}
-							align={"center"}
-						>
-							<StyledIcon src={FramerMotionIcon} title="Framer Motion" alt="Framer Motion" />
-							<StyledIcon src={FigmaIcon} title="Figma" alt="Figma" />
-							<StyledIcon src={FramerIcon} title="Framer" alt="Framer" />
-							<StyledIcon src={AISDKIcon} title="AI SDK" alt="AI SDK" />
-						</Container>
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={1280} maxWidth={1439}>
-				<Container
-					w={"100%"}
-					h={"100%"}
-					m={["36", "0", "36", "0"]}
-					direction={"column"}
-					justify={"center"}
-					align={"center"}
-					gap={"36px"}
-				>
-					<Container
-						w={"100%"}
-						h={"auto"}
-						justify={"flex-start"}
-						align={"center"}
-					>
-						<Text as="h2" variant={"subtitle-snd"} >
-							SKILLS & TOOLS
-						</Text>
-					</Container>
-					<Container
-						h={"100%"}
-						direction={"column"}
-						justify={"center"}
-						align={"center"}
-						gap={"24px"}
-					>
-						<Container
-							justify={"space-between"}
-							align={"center"}
-						>
-							<StyledIcon src={BashIcon} title="Bash" alt="Bash" />
-							<StyledIcon src={NodeJSIcon} title="Node.js" alt="Node.js" />
-							<StyledIcon src={JSIcon} title="JavaScript" alt="JavaScript" />
-							<StyledIcon src={TSIcon} title="TypeScript" alt="TypeScript" />
-						</Container>
-						<Container
-							justify={"space-between"}
-							align={"center"}
-						>
-							<StyledIcon src={CSSIcon} title="CSS" alt="CSS" />
-							<StyledIcon src={WCIcon} title="Web Components" alt="Web Components" />
-							<StyledIcon src={ReactJSIcon} title="React.js" alt="React.js" />
-							<StyledIcon src={NextJSIcon} title="Next.js" alt="Next.js" />
-						</Container>
-						<Container justify={"space-between"} align={"center"}>
-							<StyledIcon src={ExpressJSIcon} title="Express.js" alt="Express.js" />
-							<StyledIcon src={PostmanIcon} title="Postman" alt="Postman" />
-							<StyledIcon src={FirebaseIcon} title="Firebase" alt="Firebase" />
-							<StyledIcon src={PostgreSQLIcon} title="PostgreSQL" alt="PostgreSQL" />
-						</Container>
-						<Container justify={"space-between"} align={"center"}>
-							<StyledIcon src={SequelizeJSIcon} title="Sequelize" alt="Sequelize" />
-							<StyledIcon src={PrismaIcon} title="Prisma" alt="Prisma" />
-							<StyledIcon src={GitIcon} title="Git" alt="Git" />
-							<StyledIcon src={ThreeJSIcon} title="Three.js" alt="Three.js" />
-						</Container>
-						<Container justify={"space-between"} align={"center"}>
-							<StyledIcon src={FramerMotionIcon} title="Framer Motion" alt="Framer Motion" />
-							<StyledIcon src={FigmaIcon} title="Figma" alt="Figma" />
-							<StyledIcon src={FramerIcon} title="Framer" alt="Framer" />
-							<StyledIcon src={AISDKIcon} title="AI SDK" alt="AI SDK" />
-						</Container>
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={1440} maxWidth={1800}>
-				<Container
-					w={"80%"}
-					h={"100%"}
-					m={["36", "0", "36", "0"]}
-					direction={"column"}
-					justify={"space-between"}
-					align={"center"}
-					gap={"36px"}
-				>
-					<Container
-						w={"100%"}
-						h={"auto"}
-						justify={"flex-start"}
-						align={"center"}
-					>
-						<Text as="h2" variant={"subtitle-snd"}>
-							SKILLS & TOOLS
-						</Text>
-					</Container>
-					<Container
-						h={"100%"}
-						direction={"column"}
-						justify={"space-between"}
-						align={"center"}
-					>
-						<Container
-							justify={"space-between"}
-							align={"center"}
-						>
-							<StyledIcon src={BashIcon} title="Bash" alt="Bash" />
-							<StyledIcon src={NodeJSIcon} title="Node.js" alt="Node.js" />
-							<StyledIcon src={JSIcon} title="JavaScript" alt="JavaScript" />
-							<StyledIcon src={TSIcon} title="TypeScript" alt="TypeScript" />
-						</Container>
-						<Container
-							justify={"space-between"}
-							align={"center"}
-						>
-							<StyledIcon src={CSSIcon} title="CSS" alt="CSS" />
-							<StyledIcon src={WCIcon} title="Web Components" alt="Web Components" />
-							<StyledIcon src={ReactJSIcon} title="React.js" alt="React.js" />
-							<StyledIcon src={NextJSIcon} title="Next.js" alt="Next.js" />
-						</Container>
-						<Container justify={"space-between"} align={"center"}>
-							<StyledIcon src={ExpressJSIcon} title="Express.js" alt="Express.js" />
-							<StyledIcon src={PostmanIcon} title="Postman" alt="Postman" />
-							<StyledIcon src={FirebaseIcon} title="Firebase" alt="Firebase" />
-							<StyledIcon src={PostgreSQLIcon} title="PostgreSQL" alt="PostgreSQL" />
-						</Container>
-						<Container justify={"space-between"} align={"center"}>
-							<StyledIcon src={SequelizeJSIcon} title="Sequelize" alt="Sequelize" />
-							<StyledIcon src={PrismaIcon} title="Prisma" alt="Prisma" />
-							<StyledIcon src={GitIcon} title="Git" alt="Git" />
-							<StyledIcon src={ThreeJSIcon} title="Three.js" alt="Three.js" />
-						</Container>
-						<Container justify={"space-between"} align={"center"}>
-							<StyledIcon src={FramerMotionIcon} title="Framer Motion" alt="Framer Motion" />
-							<StyledIcon src={FigmaIcon} title="Figma" alt="Figma" />
-							<StyledIcon src={FramerIcon} title="Framer" alt="Framer" />
-							<StyledIcon src={AISDKIcon} title="AI SDK" alt="AI SDK" />
-						</Container>
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={1801}>
-				<Text as="h2" variant={"subtitle-snd"} m={["48", "0", "36", "0"]}>
+	const iconGrid = skillRows.map((row, i) => (
+		<Container
+			key={i}
+			w={cfg.iconRowW}
+			justify={cfg.iconRowJustify}
+			align={"center"}
+		>
+			{row.map((icon) => (
+				<StyledIcon
+					key={icon.title}
+					src={icon.src}
+					title={icon.title}
+					alt={icon.title}
+				/>
+			))}
+		</Container>
+	));
+
+	if (cfg.titleOutside) {
+		return (
+			<StyledSkills flex={props.flex}>
+				<Text as="h2" variant={"subtitle-snd"} m={cfg.titleM}>
 					SKILLS & TOOLS
 				</Text>
 				<Container
-					h={"70%"}
+					h={cfg.outerH}
 					m={["36", "0", "36", "0"]}
-					p={["0", "72", "0", "72"]}
+					p={cfg.iconContainerP}
 					direction={"column"}
 					justify={"center"}
 					align={"center"}
 				>
-					<Container
-						justify={"space-between"}
-						align={"center"}
-					>
-						<StyledIcon src={BashIcon} title="Bash" alt="Bash" />
-						<StyledIcon src={NodeJSIcon} title="Node.js" alt="Node.js" />
-						<StyledIcon src={JSIcon} title="JavaScript" alt="JavaScript" />
-						<StyledIcon src={TSIcon} title="TypeScript" alt="TypeScript" />
-					</Container>
-					<Container
-						justify={"space-between"}
-						align={"center"}
-					>
-						<StyledIcon src={CSSIcon} title="CSS" alt="CSS" />
-						<StyledIcon src={WCIcon} title="Web Components" alt="Web Components" />
-						<StyledIcon src={ReactJSIcon} title="React.js" alt="React.js" />
-						<StyledIcon src={NextJSIcon} title="Next.js" alt="Next.js" />
-					</Container>
-					<Container justify={"space-between"} align={"center"}>
-						<StyledIcon src={ExpressJSIcon} title="Express.js" alt="Express.js" />
-						<StyledIcon src={PostmanIcon} title="Postman" alt="Postman" />
-						<StyledIcon src={FirebaseIcon} title="Firebase" alt="Firebase" />
-						<StyledIcon src={PostgreSQLIcon} title="PostgreSQL" alt="PostgreSQL" />
-					</Container>
-					<Container justify={"space-between"} align={"center"}>
-						<StyledIcon src={SequelizeJSIcon} title="Sequelize" alt="Sequelize" />
-						<StyledIcon src={PrismaIcon} title="Prisma" alt="Prisma" />
-						<StyledIcon src={GitIcon} title="Git" alt="Git" />
-						<StyledIcon src={ThreeJSIcon} title="Three.js" alt="Three.js" />
-					</Container>
-					<Container justify={"space-between"} align={"center"}>
-						<StyledIcon src={FramerMotionIcon} title="Framer Motion" alt="Framer Motion" />
-						<StyledIcon src={FigmaIcon} title="Figma" alt="Figma" />
-						<StyledIcon src={FramerIcon} title="Framer" alt="Framer" />
-						<StyledIcon src={AISDKIcon} title="AI SDK" alt="AI SDK" />
-					</Container>
+					{iconGrid}
 				</Container>
-			</MediaQuery>
+			</StyledSkills>
+		);
+	}
+
+	const needsIconWrapper = cfg.iconWrapperH != null;
+
+	return (
+		<StyledSkills flex={props.flex}>
+			<Container
+				w={cfg.outerW}
+				maxW={cfg.outerMaxW}
+				h={cfg.outerH}
+				m={["36", "0", "36", "0"]}
+				direction={"column"}
+				justify={cfg.outerJustify}
+				align={"center"}
+				gap={"36px"}
+			>
+				<Container
+					w={"100%"}
+					h={cfg.iconWrapperH ? undefined : "100%"}
+					justify={"flex-start"}
+					align={"center"}
+				>
+					<Text as="h2" variant={"subtitle-snd"}>
+						SKILLS & TOOLS
+					</Text>
+				</Container>
+				{needsIconWrapper ? (
+					<Container
+						h={cfg.iconWrapperH}
+						direction={"column"}
+						justify={"center"}
+						align={"center"}
+						gap={cfg.iconWrapperGap}
+					>
+						{iconGrid}
+					</Container>
+				) : (
+					iconGrid
+				)}
+			</Container>
 		</StyledSkills>
 	);
 }

--- a/src/components/Containers/Works.tsx
+++ b/src/components/Containers/Works.tsx
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import MediaQuery from "react-responsive";
 
 //* Components
 import Container from "./Container";
@@ -8,6 +7,10 @@ import Text from "../Text";
 
 //? Types
 import { SectionProps } from "../../types";
+
+//? Hooks & Config
+import { useBreakpoint } from "../../hooks/useBreakpoint";
+import { worksConfig } from "../../config/responsive";
 
 //* Assets
 import patternVector from "../../assets/vectors/pattern-vector.svg";
@@ -46,193 +49,78 @@ const StyledWorks = styled.section<{
 			border-right: 1px solid var(--secondary-60);
 		}
 	}
-
-	@media (min-width: 1440px) {
-		& {
-		}
-	}
 `;
 
 function Works(props: SectionProps) {
+	const bp = useBreakpoint();
+	const cfg = worksConfig[bp];
+
+	if (cfg.titleOutside) {
+		return (
+			<StyledWorks flex={props.flex}>
+				<Container
+					h={"auto"}
+					w={cfg.outerW}
+					justify={"start"}
+					align={"center"}
+				>
+					<Text
+						as="h2"
+						variant={"subtitle-snd"}
+						m={cfg.titleM}
+					>
+						WORK
+					</Text>
+				</Container>
+				<Container
+					$css={cfg.carouselCss}
+					minH={cfg.carouselMinH}
+					w={cfg.carouselW}
+					direction={cfg.carouselDirection}
+					justify={"center"}
+					align={"center"}
+				>
+					<WorkCardsCarousel />
+				</Container>
+			</StyledWorks>
+		);
+	}
+
 	return (
 		<StyledWorks flex={props.flex}>
-			<MediaQuery minWidth={360} maxWidth={767}>
+			<Container
+				h={cfg.outerH}
+				w={cfg.outerW}
+				maxW={cfg.outerMaxW}
+				m={["36", "0", "36", "0"]}
+				direction={"column"}
+				justify={"center"}
+				align={"center"}
+				gap={"36px"}
+			>
 				<Container
-					h={"100%"}
+					h={bp === 'mobile-sm' ? "100%" : "auto"}
 					w={"100%"}
-					maxW={"500px"}
-					m={["36", "0", "36", "0"]}
-					direction={"column"}
-					justify={"center"}
-					align={"center"}
-					gap={"36px"}
-				>
-					<Container
-						h={"100%"}
-						w={"100%"}
-						justify={"start"}
-						align={"center"}
-					>
-						<Text
-							as="h2"
-							variant={"subtitle-snd"}
-						>
-							WORK
-						</Text>
-					</Container>
-					<Container
-						direction={"column"}
-						justify={"center"}
-						align={"center"}
-					>
-						<WorkCardsCarousel />
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={768} maxWidth={959}>
-				<Container
-					h={"100%"}
-					w={"80%"}
-					m={["36", "0", "36", "0"]}
-					direction={"column"}
-					justify={"center"}
-					align={"center"}
-					gap={"36px"}
-				>
-					<Container
-						h={"auto"}
-						w={"100%"}
-						justify={"flex-start"}
-						align={"center"}
-					>
-						<Text
-							as="h2"
-							variant={"subtitle-snd"}
-						>
-							WORK
-						</Text>
-					</Container>
-					<Container
-						direction={"column"}
-						justify={"center"}
-						align={"center"}
-					>
-						<WorkCardsCarousel />
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={960} maxWidth={1279}>
-				<Container
-					h={"100%"}
-					w={"80%"}
-					m={["36", "0", "36", "0"]}
-					direction={"column"}
-					justify={"center"}
-					align={"center"}
-					gap={"36px"}
-				>
-					<Container
-						h={"auto"}
-						w={"100%"}
-						justify={"start"}
-						align={"center"}
-					>
-						<Text
-							as="h2"
-							variant={"subtitle-snd"}
-						>
-							WORK
-						</Text>
-					</Container>
-					<Container
-						$css={"overflow: hidden;"}
-						w={"100vw"}
-						direction={"column"}
-						justify={"center"}
-						align={"center"}
-					>
-						<WorkCardsCarousel />
-					</Container>
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={1280} maxWidth={1439}>
-				<Container
-					h={"auto"}
-					w={"90%"}
-					justify={"start"}
+					justify={bp === 'mobile-sm' ? "start" : "flex-start"}
 					align={"center"}
 				>
 					<Text
 						as="h2"
 						variant={"subtitle-snd"}
-						m={["36", "0", "0", "0"]}
 					>
 						WORK
 					</Text>
 				</Container>
 				<Container
-					$css={"overflow: hidden;"}
-					minH={"402px"}
-					w={"56.4vw"}
-					direction={"row"}
+					$css={cfg.carouselCss}
+					w={cfg.carouselW}
+					direction={"column"}
 					justify={"center"}
 					align={"center"}
 				>
 					<WorkCardsCarousel />
 				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={1440} maxWidth={1800}>
-				<Container
-					h={"auto"}
-					w={"90%"}
-					justify={"start"}
-					align={"center"}
-				>
-					<Text
-						as="h2"
-						variant={"subtitle-snd"}
-						m={["36", "0", "0", "0"]}
-					>
-						WORK
-					</Text>
-				</Container>
-				<Container
-					$css={"overflow: hidden;"}
-					minH={"402px"}
-					w={"57.1vw"}
-					direction={"row"}
-					justify={"center"}
-					align={"center"}
-				>
-					<WorkCardsCarousel />
-				</Container>
-			</MediaQuery>
-			<MediaQuery minWidth={1801}>
-				<Container
-					h={"auto"}
-					w={"90%"}
-					justify={"start"}
-					align={"center"}
-				>
-					<Text
-						as="h2"
-						variant={"subtitle-snd"}
-						m={["48", "0", "0", "0"]}
-					>
-						WORK
-					</Text>
-				</Container>
-				<Container
-					$css={"overflow: hidden;"}
-					minH={"402px"}
-					w={"57.55vw"}
-					direction={"row"}
-					justify={"center"}
-					align={"center"}
-				>
-					<WorkCardsCarousel />
-				</Container>
-			</MediaQuery>
+			</Container>
 		</StyledWorks>
 	);
 }

--- a/src/components/WorkCardsCarousel/index.tsx
+++ b/src/components/WorkCardsCarousel/index.tsx
@@ -1,4 +1,3 @@
-import MediaQuery, { useMediaQuery } from 'react-responsive';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
 //* Swiper Modules
@@ -12,470 +11,58 @@ import './swiper.style.css';
 import WorkCard from '../WorkCard';
 import Container from '../Containers/Container';
 
-//* Assets
-import moldeLogo from '../../assets/works/molde.svg';
-import indaloLogo from '../../assets/works/indalo.svg';
-import ranchoLogo from '../../assets/works/rancho.svg';
-import clamacoLogo from '../../assets/works/clamaco.svg';
+//? Hooks, Config & Data
+import { useBreakpoint, isDesktop } from '../../hooks/useBreakpoint';
+import { carouselConfig } from '../../config/responsive';
+import { works } from '../../data/works';
 
 export default function WorkCardsCarousel() {
-	const isDesktop = useMediaQuery({ minWidth: 960 });
+	const bp = useBreakpoint();
+	const cfg = carouselConfig[bp];
+
+	if (!cfg.useSwiper) {
+		return (
+			<Container direction={"column"} justify={"center"} align={"center"} gap={"20px"}>
+				{works.map((work) => (
+					<WorkCard
+						key={work.title}
+						title={work.title}
+						tags={work.tags}
+						details={work.details}
+						url={work.url}
+						showcaseUrl={work.showcaseUrl}
+						src={work.src}
+					/>
+				))}
+			</Container>
+		);
+	}
+
+	const swiperItems = [...works, ...works];
 
 	return (
-		<>
-			<MediaQuery minWidth={360} maxWidth={959}>
-				<Container direction={"column"} justify={"center"} align={"center"} gap={"20px"}>
-					< WorkCard
-						title={'Molde'}
-						tags={['Development']}
-						details={`Landing Page for an architecture studio.`}
-						url={'https://www.estudiomolde.com/'}
-						showcaseUrl={
-							'https://contra.com/p/o3YcvW6c-molde-architecture-studio-development'
-						}
-						src={moldeLogo}
-					/>
+		<Swiper
+			className="swiper"
+			modules={[Autoplay]}
+			autoplay={true}
+			loop={true}
+			centeredSlides={cfg.centeredSlides}
+			slidesPerView={cfg.slidesPerView}
+			spaceBetween={cfg.spaceBetween}
+			direction={isDesktop(bp) ? 'horizontal' : 'horizontal'}
+		>
+			{swiperItems.map((work, i) => (
+				<SwiperSlide key={`${work.title}-${i}`} className="swiper-slide">
 					<WorkCard
-						title={'Indalo'}
-						tags={['Development']}
-						details={'Landing Page for an enterprises group'}
-						url={'https://www.grupoindalo.com.ar/'}
-						showcaseUrl={
-							'https://contra.com/p/WPl3g6WF-indalo-enterprises-group-development'
-						}
-						src={indaloLogo}
+						title={work.title}
+						tags={work.tags}
+						details={work.details}
+						url={work.url}
+						showcaseUrl={work.showcaseUrl}
+						src={work.src}
 					/>
-					<WorkCard
-						title={'Rancho'}
-						tags={['Design', 'Development']}
-						details={'Landing Page for a rental business'}
-						url={'https://bungalowselrancho.com.ar/'}
-						showcaseUrl={
-							'https://contra.com/p/XFlM23XE-el-rancho-family-run-rental-business-design-and-development'
-						}
-						src={ranchoLogo}
-					/>
-					<WorkCard
-						title={'Clamaco'}
-						tags={['Design']}
-						details={'Landing Page for a construction company'}
-						url={'https://clamaco.com.ar/'}
-						src={clamacoLogo}
-					/>
-				</Container>
-			</MediaQuery >
-			<MediaQuery minWidth={960} maxWidth={1279}>
-				<Swiper
-					className="swiper"
-					modules={[Autoplay]}
-					autoplay={true}
-					loop={true}
-					centeredSlides={true}
-					slidesPerView={1}
-					spaceBetween={5}
-					direction={isDesktop ? 'horizontal' : 'vertical'}
-				>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Molde'}
-							tags={['Development']}
-							details={`Landing Page for an architecture studio.`}
-							url={'https://www.estudiomolde.com/'}
-							showcaseUrl={
-								'https://contra.com/p/o3YcvW6c-molde-architecture-studio-development'
-							}
-							src={moldeLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Indalo'}
-							tags={['Development']}
-							details={'Landing Page for an enterprises group'}
-							url={'https://www.grupoindalo.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/WPl3g6WF-indalo-enterprises-group-development'
-							}
-							src={indaloLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Rancho'}
-							tags={['Design', 'Development']}
-							details={'Landing Page for a rental business'}
-							url={'https://bungalowselrancho.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/XFlM23XE-el-rancho-family-run-rental-business-design-and-development'
-							}
-							src={ranchoLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Clamaco'}
-							tags={['Design']}
-							details={'Landing Page for a construction company'}
-							url={'https://clamaco.com.ar/'}
-							src={clamacoLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Molde'}
-							tags={['Development']}
-							details={`Landing Page for an architecture studio.`}
-							url={'https://www.estudiomolde.com/'}
-							showcaseUrl={
-								'https://contra.com/p/o3YcvW6c-molde-architecture-studio-development'
-							}
-							src={moldeLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Indalo'}
-							tags={['Development']}
-							details={'Landing Page for an enterprises group'}
-							url={'https://www.grupoindalo.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/WPl3g6WF-indalo-enterprises-group-development'
-							}
-							src={indaloLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Rancho'}
-							tags={['Design', 'Development']}
-							details={'Landing Page for a rental business'}
-							url={'https://bungalowselrancho.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/XFlM23XE-el-rancho-family-run-rental-business-design-and-development'
-							}
-							src={ranchoLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Clamaco'}
-							tags={['Design']}
-							details={'Landing Page for a construction company'}
-							url={'https://clamaco.com.ar/'}
-							src={clamacoLogo}
-						/>
-					</SwiperSlide>
-				</Swiper>
-			</MediaQuery>
-			<MediaQuery minWidth={1280} maxWidth={1439}>
-				<Swiper
-					className="swiper"
-					modules={[Autoplay]}
-					autoplay={true}
-					loop={true}
-					centeredSlides={false}
-					slidesPerView={2}
-					spaceBetween={10}
-					direction={isDesktop ? 'horizontal' : 'vertical'}
-				>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Molde'}
-							tags={['Development']}
-							details={`Landing Page for an architecture studio.`}
-							url={'https://www.estudiomolde.com/'}
-							showcaseUrl={
-								'https://contra.com/p/o3YcvW6c-molde-architecture-studio-development'
-							}
-							src={moldeLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Indalo'}
-							tags={['Development']}
-							details={'Landing Page for an enterprises group'}
-							url={'https://www.grupoindalo.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/WPl3g6WF-indalo-enterprises-group-development'
-							}
-							src={indaloLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Rancho'}
-							tags={['Design', 'Development']}
-							details={'Landing Page for a rental business'}
-							url={'https://bungalowselrancho.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/XFlM23XE-el-rancho-family-run-rental-business-design-and-development'
-							}
-							src={ranchoLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Clamaco'}
-							tags={['Design']}
-							details={'Landing Page for a construction company'}
-							url={'https://clamaco.com.ar/'}
-							src={clamacoLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Molde'}
-							tags={['Development']}
-							details={`Landing Page for an architecture studio.`}
-							url={'https://www.estudiomolde.com/'}
-							showcaseUrl={
-								'https://contra.com/p/o3YcvW6c-molde-architecture-studio-development'
-							}
-							src={moldeLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Indalo'}
-							tags={['Development']}
-							details={'Landing Page for an enterprises group'}
-							url={'https://www.grupoindalo.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/WPl3g6WF-indalo-enterprises-group-development'
-							}
-							src={indaloLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Rancho'}
-							tags={['Design', 'Development']}
-							details={'Landing Page for a rental business'}
-							url={'https://bungalowselrancho.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/XFlM23XE-el-rancho-family-run-rental-business-design-and-development'
-							}
-							src={ranchoLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Clamaco'}
-							tags={['Design']}
-							details={'Landing Page for a construction company'}
-							url={'https://clamaco.com.ar/'}
-							src={clamacoLogo}
-						/>
-					</SwiperSlide>
-				</Swiper>
-			</MediaQuery>
-			<MediaQuery minWidth={1440} maxWidth={1800}>
-				<Swiper
-					className="swiper"
-					modules={[Autoplay]}
-					autoplay={true}
-					loop={true}
-					centeredSlides={false}
-					slidesPerView={2}
-					spaceBetween={10}
-					direction={isDesktop ? 'horizontal' : 'vertical'}
-				>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Molde'}
-							tags={['Development']}
-							details={`Landing Page for an architecture studio.`}
-							url={'https://www.estudiomolde.com/'}
-							showcaseUrl={
-								'https://contra.com/p/o3YcvW6c-molde-architecture-studio-development'
-							}
-							src={moldeLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Indalo'}
-							tags={['Development']}
-							details={'Landing Page for an enterprises group'}
-							url={'https://www.grupoindalo.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/WPl3g6WF-indalo-enterprises-group-development'
-							}
-							src={indaloLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Rancho'}
-							tags={['Design', 'Development']}
-							details={'Landing Page for a rental business'}
-							url={'https://bungalowselrancho.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/XFlM23XE-el-rancho-family-run-rental-business-design-and-development'
-							}
-							src={ranchoLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Clamaco'}
-							tags={['Design']}
-							details={'Landing Page for a construction company'}
-							url={'https://clamaco.com.ar/'}
-							src={clamacoLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Molde'}
-							tags={['Development']}
-							details={`Landing Page for an architecture studio.`}
-							url={'https://www.estudiomolde.com/'}
-							showcaseUrl={
-								'https://contra.com/p/o3YcvW6c-molde-architecture-studio-development'
-							}
-							src={moldeLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Indalo'}
-							tags={['Development']}
-							details={'Landing Page for an enterprises group'}
-							url={'https://www.grupoindalo.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/WPl3g6WF-indalo-enterprises-group-development'
-							}
-							src={indaloLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Rancho'}
-							tags={['Design', 'Development']}
-							details={'Landing Page for a rental business'}
-							url={'https://bungalowselrancho.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/XFlM23XE-el-rancho-family-run-rental-business-design-and-development'
-							}
-							src={ranchoLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Clamaco'}
-							tags={['Design']}
-							details={'Landing Page for a construction company'}
-							url={'https://clamaco.com.ar/'}
-							src={clamacoLogo}
-						/>
-					</SwiperSlide>
-				</Swiper>
-			</MediaQuery>
-			<MediaQuery minWidth={1801}>
-				<Swiper
-					className="swiper"
-					modules={[Autoplay]}
-					autoplay={true}
-					loop={true}
-					centeredSlides={false}
-					slidesPerView={3}
-					spaceBetween={10}
-					direction={isDesktop ? 'horizontal' : 'vertical'}
-				>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Molde'}
-							tags={['Development']}
-							details={`Landing Page for an architecture studio.`}
-							url={'https://www.estudiomolde.com/'}
-							showcaseUrl={
-								'https://contra.com/p/o3YcvW6c-molde-architecture-studio-development'
-							}
-							src={moldeLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Indalo'}
-							tags={['Development']}
-							details={'Landing Page for an enterprises group'}
-							url={'https://www.grupoindalo.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/WPl3g6WF-indalo-enterprises-group-development'
-							}
-							src={indaloLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Rancho'}
-							tags={['Design', 'Development']}
-							details={'Landing Page for a rental business'}
-							url={'https://bungalowselrancho.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/XFlM23XE-el-rancho-family-run-rental-business-design-and-development'
-							}
-							src={ranchoLogo}
-						/>{' '}
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Clamaco'}
-							tags={['Design']}
-							details={'Landing Page for a construction company'}
-							url={'https://clamaco.com.ar/'}
-							src={clamacoLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Molde'}
-							tags={['Development']}
-							details={`Landing Page for an architecture studio.`}
-							url={'https://www.estudiomolde.com/'}
-							showcaseUrl={
-								'https://contra.com/p/o3YcvW6c-molde-architecture-studio-development'
-							}
-							src={moldeLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Indalo'}
-							tags={['Development']}
-							details={'Landing Page for an enterprises group'}
-							url={'https://www.grupoindalo.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/WPl3g6WF-indalo-enterprises-group-development'
-							}
-							src={indaloLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Rancho'}
-							tags={['Design', 'Development']}
-							details={'Landing Page for a rental business'}
-							url={'https://bungalowselrancho.com.ar/'}
-							showcaseUrl={
-								'https://contra.com/p/XFlM23XE-el-rancho-family-run-rental-business-design-and-development'
-							}
-							src={ranchoLogo}
-						/>
-					</SwiperSlide>
-					<SwiperSlide className="swiper-slide">
-						<WorkCard
-							title={'Clamaco'}
-							tags={['Design']}
-							details={'Landing Page for a construction company'}
-							url={'https://clamaco.com.ar/'}
-							src={clamacoLogo}
-						/>
-					</SwiperSlide>
-				</Swiper>
-			</MediaQuery>
-		</>
+				</SwiperSlide>
+			))}
+		</Swiper>
 	);
 }

--- a/src/config/responsive.ts
+++ b/src/config/responsive.ts
@@ -1,0 +1,351 @@
+import { Breakpoint } from '../hooks/useBreakpoint';
+
+interface AboutConfig {
+	outerW: string;
+	outerMaxW?: string;
+	outerH?: string;
+	outerMinH?: string;
+	outerGap: string;
+	paragraphGap: string;
+	paragraphVariant: string;
+	titleAlign?: string;
+	innerW?: string;
+}
+
+export const aboutConfig: Record<Breakpoint, AboutConfig> = {
+	'mobile-sm': {
+		outerW: '100%',
+		outerMaxW: '500px',
+		outerH: '100%',
+		outerGap: '24px',
+		paragraphGap: '12px',
+		paragraphVariant: 'paragraph',
+	},
+	'mobile-lg': {
+		outerW: '80%',
+		outerGap: '24px',
+		paragraphGap: '12px',
+		paragraphVariant: 'paragraph',
+	},
+	tablet: {
+		outerW: '80%',
+		outerGap: '24px',
+		paragraphGap: '12px',
+		paragraphVariant: 'paragraph',
+		titleAlign: 'left',
+	},
+	'desktop-sm': {
+		outerW: '100%',
+		outerH: '100%',
+		outerMinH: '450px',
+		outerGap: '36px',
+		paragraphGap: '20px',
+		paragraphVariant: 'paragraph',
+		titleAlign: 'left',
+	},
+	'desktop-md': {
+		outerW: '100%',
+		outerH: '100%',
+		outerMinH: '450px',
+		outerGap: '36px',
+		paragraphGap: '20px',
+		paragraphVariant: 'paragraph',
+	},
+	'desktop-lg': {
+		outerW: '100%',
+		outerH: '100%',
+		outerMinH: '490px',
+		outerGap: '36px',
+		paragraphGap: '20px',
+		paragraphVariant: 'paragraph-desktop',
+	},
+	'desktop-xl': {
+		outerW: '100%',
+		outerH: '100%',
+		outerMinH: '530px',
+		outerGap: '36px',
+		paragraphGap: '20px',
+		paragraphVariant: 'paragraph-desktop',
+		innerW: '80%',
+	},
+};
+
+interface SkillsConfig {
+	outerW: string;
+	outerMaxW?: string;
+	outerH: string;
+	outerJustify: string;
+	iconRowW?: string;
+	iconRowJustify: string;
+	iconWrapperH?: string;
+	iconWrapperGap?: string;
+	titleOutside: boolean;
+	titleM?: string[];
+	iconContainerP?: string[];
+}
+
+export const skillsConfig: Record<Breakpoint, SkillsConfig> = {
+	'mobile-sm': {
+		outerW: '100%',
+		outerMaxW: '500px',
+		outerH: '70%',
+		outerJustify: 'center',
+		iconRowJustify: 'space-between',
+		titleOutside: false,
+	},
+	'mobile-lg': {
+		outerW: '80%',
+		outerH: '70%',
+		outerJustify: 'center',
+		iconRowW: '100%',
+		iconRowJustify: 'space-evenly',
+		iconWrapperH: '70%',
+		iconWrapperGap: '24px',
+		titleOutside: false,
+	},
+	tablet: {
+		outerW: '80%',
+		outerH: '100%',
+		outerJustify: 'center',
+		iconRowW: '70%',
+		iconRowJustify: 'space-evenly',
+		iconWrapperH: '70%',
+		iconWrapperGap: '24px',
+		titleOutside: false,
+	},
+	'desktop-sm': {
+		outerW: '100%',
+		outerH: '100%',
+		outerJustify: 'center',
+		iconRowJustify: 'space-between',
+		iconWrapperH: '100%',
+		iconWrapperGap: '24px',
+		titleOutside: false,
+	},
+	'desktop-md': {
+		outerW: '100%',
+		outerH: '100%',
+		outerJustify: 'center',
+		iconRowJustify: 'space-between',
+		iconWrapperH: '100%',
+		iconWrapperGap: '24px',
+		titleOutside: false,
+	},
+	'desktop-lg': {
+		outerW: '80%',
+		outerH: '100%',
+		outerJustify: 'space-between',
+		iconRowJustify: 'space-between',
+		iconWrapperH: '100%',
+		titleOutside: false,
+	},
+	'desktop-xl': {
+		outerW: '100%',
+		outerH: '70%',
+		outerJustify: 'center',
+		iconRowJustify: 'space-between',
+		titleOutside: true,
+		titleM: ['48', '0', '36', '0'],
+		iconContainerP: ['0', '72', '0', '72'],
+	},
+};
+
+interface ProjectsConfig {
+	outerW: string;
+	outerMaxW?: string;
+	outerH: string;
+	outerMinH?: string;
+	outerJustify: string;
+	titleJustify: string;
+	titleH?: string;
+	cardGap: string;
+}
+
+export const projectsConfig: Record<Breakpoint, ProjectsConfig> = {
+	'mobile-sm': {
+		outerW: '100%',
+		outerMaxW: '500px',
+		outerH: '80%',
+		outerJustify: 'center',
+		titleJustify: 'flex-start',
+		titleH: undefined,
+		cardGap: '12px',
+	},
+	'mobile-lg': {
+		outerW: '80%',
+		outerH: '80%',
+		outerJustify: 'center',
+		titleJustify: 'flex-start',
+		titleH: '100%',
+		cardGap: '12px',
+	},
+	tablet: {
+		outerW: '80%',
+		outerH: '100%',
+		outerJustify: 'center',
+		titleJustify: 'flex-start',
+		titleH: '100%',
+		cardGap: '12px',
+	},
+	'desktop-sm': {
+		outerW: '100%',
+		outerH: '100%',
+		outerMinH: '450px',
+		outerJustify: 'space-between',
+		titleJustify: 'space-between',
+		titleH: '100%',
+		cardGap: '20px',
+	},
+	'desktop-md': {
+		outerW: '100%',
+		outerH: '100%',
+		outerMinH: '450px',
+		outerJustify: 'space-between',
+		titleJustify: 'space-between',
+		titleH: '100%',
+		cardGap: '20px',
+	},
+	'desktop-lg': {
+		outerW: '100%',
+		outerH: '100%',
+		outerMinH: '490px',
+		outerJustify: 'space-between',
+		titleJustify: 'space-between',
+		titleH: '100%',
+		cardGap: '20px',
+	},
+	'desktop-xl': {
+		outerW: '75%',
+		outerH: '100%',
+		outerMinH: '530px',
+		outerJustify: 'space-between',
+		titleJustify: 'flex-start',
+		cardGap: '20px',
+	},
+};
+
+interface WorksConfig {
+	titleOutside: boolean;
+	titleM?: string[];
+	outerW: string;
+	outerMaxW?: string;
+	outerH: string;
+	carouselCss?: string;
+	carouselMinH?: string;
+	carouselW?: string;
+	carouselDirection?: string;
+}
+
+export const worksConfig: Record<Breakpoint, WorksConfig> = {
+	'mobile-sm': {
+		titleOutside: false,
+		outerW: '100%',
+		outerMaxW: '500px',
+		outerH: '100%',
+	},
+	'mobile-lg': {
+		titleOutside: false,
+		outerW: '80%',
+		outerH: '100%',
+	},
+	tablet: {
+		titleOutside: false,
+		outerW: '80%',
+		outerH: '100%',
+		carouselCss: 'overflow: hidden;',
+		carouselW: '100vw',
+	},
+	'desktop-sm': {
+		titleOutside: true,
+		titleM: ['36', '0', '0', '0'],
+		outerW: '90%',
+		outerH: 'auto',
+		carouselCss: 'overflow: hidden;',
+		carouselMinH: '402px',
+		carouselW: '56.4vw',
+		carouselDirection: 'row',
+	},
+	'desktop-md': {
+		titleOutside: true,
+		titleM: ['36', '0', '0', '0'],
+		outerW: '90%',
+		outerH: 'auto',
+		carouselCss: 'overflow: hidden;',
+		carouselMinH: '402px',
+		carouselW: '56.4vw',
+		carouselDirection: 'row',
+	},
+	'desktop-lg': {
+		titleOutside: true,
+		titleM: ['36', '0', '0', '0'],
+		outerW: '90%',
+		outerH: 'auto',
+		carouselCss: 'overflow: hidden;',
+		carouselMinH: '402px',
+		carouselW: '57.1vw',
+		carouselDirection: 'row',
+	},
+	'desktop-xl': {
+		titleOutside: true,
+		titleM: ['48', '0', '0', '0'],
+		outerW: '90%',
+		outerH: 'auto',
+		carouselCss: 'overflow: hidden;',
+		carouselMinH: '402px',
+		carouselW: '57.55vw',
+		carouselDirection: 'row',
+	},
+};
+
+interface CarouselConfig {
+	useSwiper: boolean;
+	slidesPerView?: number;
+	centeredSlides?: boolean;
+	spaceBetween?: number;
+}
+
+export const carouselConfig: Record<Breakpoint, CarouselConfig> = {
+	'mobile-sm': { useSwiper: false },
+	'mobile-lg': { useSwiper: false },
+	tablet: { useSwiper: true, slidesPerView: 1, centeredSlides: true, spaceBetween: 5 },
+	'desktop-sm': { useSwiper: true, slidesPerView: 2, centeredSlides: false, spaceBetween: 10 },
+	'desktop-md': { useSwiper: true, slidesPerView: 2, centeredSlides: false, spaceBetween: 10 },
+	'desktop-lg': { useSwiper: true, slidesPerView: 2, centeredSlides: false, spaceBetween: 10 },
+	'desktop-xl': { useSwiper: true, slidesPerView: 3, centeredSlides: false, spaceBetween: 10 },
+};
+
+interface HomeConfig {
+	isDesktopLayout: boolean;
+	skillsWorkMinH?: string;
+	skillsWorkH?: string;
+	skillsWorkAlign?: string;
+	innerH?: string;
+}
+
+export const homeConfig: Record<Breakpoint, HomeConfig> = {
+	'mobile-sm': { isDesktopLayout: false },
+	'mobile-lg': { isDesktopLayout: false },
+	tablet: { isDesktopLayout: false },
+	'desktop-sm': {
+		isDesktopLayout: true,
+		skillsWorkMinH: '462px',
+		skillsWorkAlign: 'start',
+	},
+	'desktop-md': {
+		isDesktopLayout: true,
+		skillsWorkMinH: '462px',
+		skillsWorkAlign: 'start',
+	},
+	'desktop-lg': {
+		isDesktopLayout: true,
+		skillsWorkH: '55vh',
+		skillsWorkMinH: '510px',
+	},
+	'desktop-xl': {
+		isDesktopLayout: true,
+		skillsWorkH: '55vh',
+		skillsWorkMinH: '530px',
+		skillsWorkAlign: 'start',
+		innerH: 'fit-content',
+	},
+};

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,35 @@
+import centryBoardVector from '../assets/vectors/centryboard.svg';
+import facheAIVector from '../assets/vectors/facheai.svg';
+import facheVector from '../assets/vectors/fache.svg';
+
+export interface ProjectItem {
+	title: string;
+	details: string;
+	tag: string;
+	src: string;
+	url: string;
+}
+
+export const projects: ProjectItem[] = [
+	{
+		title: 'CentryBoard',
+		details: 'Productivity Booster App',
+		tag: 'Work in progress',
+		src: centryBoardVector,
+		url: 'https://centryboard.site/',
+	},
+	{
+		title: 'fache.ai',
+		details: 'AI Assistant App',
+		tag: 'Work in progress',
+		src: facheAIVector,
+		url: 'https://fache-ai-agent.vercel.app/',
+	},
+	{
+		title: 'fache.',
+		details: 'Personal Website',
+		tag: 'V2.0',
+		src: facheVector,
+		url: 'https://fache.vercel.app',
+	},
+];

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,0 +1,58 @@
+import BashIcon from '../assets/icons/Bash.svg';
+import TSIcon from '../assets/icons/TypeScript.svg';
+import NodeJSIcon from '../assets/icons/NodeJS.svg';
+import JSIcon from '../assets/icons/JavaScript.svg';
+import CSSIcon from '../assets/icons/CSS.svg';
+import WCIcon from '../assets/icons/WebComponents.svg';
+import ReactJSIcon from '../assets/icons/ReactJS.svg';
+import NextJSIcon from '../assets/icons/NextJS.svg';
+import ExpressJSIcon from '../assets/icons/ExpressJS.svg';
+import PostmanIcon from '../assets/icons/Postman.svg';
+import FirebaseIcon from '../assets/icons/Firebase.svg';
+import PostgreSQLIcon from '../assets/icons/PostgreSQL.svg';
+import SequelizeJSIcon from '../assets/icons/SequelizeJS.svg';
+import PrismaIcon from '../assets/icons/Prisma.svg';
+import GitIcon from '../assets/icons/Git.svg';
+import ThreeJSIcon from '../assets/icons/ThreeJS.svg';
+import FramerMotionIcon from '../assets/icons/FramerMotion.svg';
+import FigmaIcon from '../assets/icons/Figma.svg';
+import FramerIcon from '../assets/icons/Framer.svg';
+import AISDKIcon from '../assets/icons/AISDK.svg';
+
+export interface SkillIcon {
+	src: string;
+	title: string;
+}
+
+export const skillRows: SkillIcon[][] = [
+	[
+		{ src: BashIcon, title: 'Bash' },
+		{ src: NodeJSIcon, title: 'Node.js' },
+		{ src: JSIcon, title: 'JavaScript' },
+		{ src: TSIcon, title: 'TypeScript' },
+	],
+	[
+		{ src: CSSIcon, title: 'CSS' },
+		{ src: WCIcon, title: 'Web Components' },
+		{ src: ReactJSIcon, title: 'React.js' },
+		{ src: NextJSIcon, title: 'Next.js' },
+	],
+	[
+		{ src: ExpressJSIcon, title: 'Express.js' },
+		{ src: PostmanIcon, title: 'Postman' },
+		{ src: FirebaseIcon, title: 'Firebase' },
+		{ src: PostgreSQLIcon, title: 'PostgreSQL' },
+	],
+	[
+		{ src: SequelizeJSIcon, title: 'Sequelize' },
+		{ src: PrismaIcon, title: 'Prisma' },
+		{ src: GitIcon, title: 'Git' },
+		{ src: ThreeJSIcon, title: 'Three.js' },
+	],
+	[
+		{ src: FramerMotionIcon, title: 'Framer Motion' },
+		{ src: FigmaIcon, title: 'Figma' },
+		{ src: FramerIcon, title: 'Framer' },
+		{ src: AISDKIcon, title: 'AI SDK' },
+	],
+];

--- a/src/data/works.ts
+++ b/src/data/works.ts
@@ -1,0 +1,48 @@
+import moldeLogo from '../assets/works/molde.svg';
+import indaloLogo from '../assets/works/indalo.svg';
+import ranchoLogo from '../assets/works/rancho.svg';
+import clamacoLogo from '../assets/works/clamaco.svg';
+
+export interface WorkItem {
+	title: string;
+	tags: string[];
+	details: string;
+	url: string;
+	showcaseUrl?: string;
+	src: string;
+}
+
+export const works: WorkItem[] = [
+	{
+		title: 'Molde',
+		tags: ['Development'],
+		details: 'Landing Page for an architecture studio.',
+		url: 'https://www.estudiomolde.com/',
+		showcaseUrl: 'https://contra.com/p/o3YcvW6c-molde-architecture-studio-development',
+		src: moldeLogo,
+	},
+	{
+		title: 'Indalo',
+		tags: ['Development'],
+		details: 'Landing Page for an enterprises group',
+		url: 'https://www.grupoindalo.com.ar/',
+		showcaseUrl: 'https://contra.com/p/WPl3g6WF-indalo-enterprises-group-development',
+		src: indaloLogo,
+	},
+	{
+		title: 'Rancho',
+		tags: ['Design', 'Development'],
+		details: 'Landing Page for a rental business',
+		url: 'https://bungalowselrancho.com.ar/',
+		showcaseUrl:
+			'https://contra.com/p/XFlM23XE-el-rancho-family-run-rental-business-design-and-development',
+		src: ranchoLogo,
+	},
+	{
+		title: 'Clamaco',
+		tags: ['Design'],
+		details: 'Landing Page for a construction company',
+		url: 'https://clamaco.com.ar/',
+		src: clamacoLogo,
+	},
+];

--- a/src/hooks/useBreakpoint.ts
+++ b/src/hooks/useBreakpoint.ts
@@ -1,0 +1,35 @@
+import { useMediaQuery } from 'react-responsive';
+
+export type Breakpoint =
+	| 'mobile-sm'
+	| 'mobile-lg'
+	| 'tablet'
+	| 'desktop-sm'
+	| 'desktop-md'
+	| 'desktop-lg'
+	| 'desktop-xl';
+
+export function useBreakpoint(): Breakpoint {
+	const isDesktopXl = useMediaQuery({ minWidth: 1801 });
+	const isDesktopLg = useMediaQuery({ minWidth: 1440 });
+	const isDesktopMd = useMediaQuery({ minWidth: 1340 });
+	const isDesktopSm = useMediaQuery({ minWidth: 1280 });
+	const isTablet = useMediaQuery({ minWidth: 960 });
+	const isMobileLg = useMediaQuery({ minWidth: 768 });
+
+	if (isDesktopXl) return 'desktop-xl';
+	if (isDesktopLg) return 'desktop-lg';
+	if (isDesktopMd) return 'desktop-md';
+	if (isDesktopSm) return 'desktop-sm';
+	if (isTablet) return 'tablet';
+	if (isMobileLg) return 'mobile-lg';
+	return 'mobile-sm';
+}
+
+export function isMobile(bp: Breakpoint): boolean {
+	return bp === 'mobile-sm' || bp === 'mobile-lg';
+}
+
+export function isDesktop(bp: Breakpoint): boolean {
+	return bp.startsWith('desktop');
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,3 @@
-import MediaQuery from 'react-responsive';
-
 import Header from '../components/Containers/Header';
 import Profile from '../components/Containers/Profile';
 import About from '../components/Containers/About';
@@ -9,49 +7,45 @@ import Works from '../components/Containers/Works';
 import Footer from '../components/Containers/Footer';
 import Container from '../components/Containers/Container';
 
+//? Hooks & Config
+import { useBreakpoint } from '../hooks/useBreakpoint';
+import { homeConfig } from '../config/responsive';
+
 function Home() {
+	const bp = useBreakpoint();
+	const cfg = homeConfig[bp];
+
+	if (!cfg.isDesktopLayout) {
+		return (
+			<>
+				<a href="#main-content" className="skip-link">
+					Skip to main content
+				</a>
+				<main id="main-content">
+					<Container
+						w={'100%'}
+						h={'100%'}
+						direction={'column'}
+					>
+						<Header />
+						<Profile />
+						<About />
+					</Container>
+					<Projects />
+					<Skills />
+					<Works />
+					<Footer />
+				</main>
+			</>
+		);
+	}
+
 	return (
 		<>
 			<a href="#main-content" className="skip-link">
 				Skip to main content
 			</a>
 			<main id="main-content">
-			{/* Mobile Layout */}
-			<MediaQuery minWidth={360} maxWidth={959}>
-				<Container
-					w={'100%'}
-					h={'100%'}
-					direction={'column'}
-				>
-					<Header />
-					<Profile />
-					<About />
-				</Container>
-				<Projects />
-				<Skills />
-				<Works />
-				<Footer />
-			</MediaQuery>
-
-			{/* Tablet Layout */}
-			<MediaQuery minWidth={960} maxWidth={1279}>
-				<Container
-					w={'100%'}
-					h={'100%'}
-					direction={'column'}
-				>
-					<Header />
-					<Profile />
-					<About />
-				</Container>
-				<Projects />
-				<Skills />
-				<Works />
-				<Footer />
-			</MediaQuery>
-
-			{/* Desktop Layout */}
-			<MediaQuery minWidth={1280} maxWidth={1439}>
 				<Container
 					w={'100%'}
 					h={'100%'}
@@ -69,13 +63,13 @@ function Home() {
 					>
 						<Container
 							w={'90%'}
-							h={"100%"}
+							h={cfg.innerH || '100%'}
 							justify={'center'}
 							align={'center'}
 							$css={`
 								border-left: 1px solid var(--secondary-60);
 								border-right: 1px solid var(--secondary-60);
-								`}
+							`}
 						>
 							<About />
 							<Profile />
@@ -86,111 +80,19 @@ function Home() {
 
 				<Container
 					w={'100%'}
-					minH={"462px"}
+					h={cfg.skillsWorkH}
+					minH={cfg.skillsWorkMinH}
 					justify={'center'}
-					align={'start'}
+					align={cfg.skillsWorkAlign}
 					$css={'border-top: 1px solid var(--secondary-60);'}
 				>
-					<Container w={'90%'} h={"100%"} justify={'center'} align={'center'}>
+					<Container w={'90%'} h={'100%'} justify={'center'} align={'center'}>
 						<Skills flex={1} />
 						<Works flex={2} />
 					</Container>
 				</Container>
 				<Footer />
-			</MediaQuery>
-			<MediaQuery minWidth={1440} maxWidth={1800}>
-				<Container
-					w={'100%'}
-					h={'100%'}
-					direction={'column'}
-					justify={'center'}
-					align={'center'}
-				>
-					<Header />
-					<Container
-						w={'100%'}
-						justify={'center'}
-						align={'center'}
-						$css={'border-top: 1px solid var(--secondary-60);'}
-					>
-						<Container
-							w={'90%'}
-							h={"100%"}
-							justify={'center'}
-							align={'center'}
-							$css={`
-								border-left: 1px solid var(--secondary-60);
-								border-right: 1px solid var(--secondary-60);
-								`}
-						>
-							<About />
-							<Profile />
-							<Projects />
-						</Container>
-					</Container>
-				</Container>
-				<Container
-					w={'100%'}
-					h={'55vh'}
-					minH={"510px"}
-					justify={'center'}
-					$css={'border-top: 1px solid var(--secondary-60);'}
-				>
-					<Container w={'90%'} justify={'center'} align={'center'}>
-						<Skills flex={1} />
-						<Works flex={2} />
-					</Container>
-				</Container>
-				<Footer />
-			</MediaQuery>
-			<MediaQuery minWidth={1801}>
-				<Container
-					w={'100%'}
-					direction={'column'}
-					justify={'center'}
-					align={'center'}
-				>
-					<Header />
-					<Container
-						w={'100%'}
-						h={'100%'}
-						justify={'center'}
-						align={'center'}
-						$css={'border-top: 1px solid var(--secondary-60);'}
-					>
-						<Container
-							w={'90%'}
-							h={"fit-content"}
-							justify={'center'}
-							align={'center'}
-							$css={`
-								border-left: 1px solid var(--secondary-60);
-								border-right: 1px solid var(--secondary-60);
-								`}
-						>
-							<About />
-							<Profile />
-							<Projects />
-						</Container>
-					</Container>
-				</Container>
-
-				<Container
-					w={'100%'}
-					h={'55vh'}
-					minH={"530px"}
-					justify={'center'}
-					align={'start'}
-					$css={'border-top: 1px solid var(--secondary-60);'}
-				>
-					<Container w={'90%'} justify={'center'} align={'center'}>
-						<Skills flex={1} />
-						<Works flex={2} />
-					</Container>
-				</Container>
-				<Footer />
-			</MediaQuery>
-		</main>
+			</main>
 		</>
 	);
 }


### PR DESCRIPTION
## Summary

- **Add `useBreakpoint` hook** that returns a typed breakpoint name (`mobile-sm` | `mobile-lg` | `tablet` | `desktop-sm` | `desktop-md` | `desktop-lg` | `desktop-xl`) using `react-responsive`
- **Extract data to dedicated files**: `src/data/works.ts`, `src/data/projects.ts`, `src/data/skills.ts` — eliminates 5-7x duplication of work items, project cards, and skill icons across breakpoints
- **Create centralized responsive config** (`src/config/responsive.ts`) with per-breakpoint layout values for About, Skills, Projects, Works, Carousel, and Home sections
- **Refactor 6 section components** to use a single JSX tree driven by config values instead of 5-7 duplicated `<MediaQuery>` blocks each

### Line count impact

| File | Before | After | Change |
|------|--------|-------|--------|
| About.tsx | 410 | 88 | -322 |
| Skills.tsx | 474 | 131 | -343 |
| WorkCardsCarousel | 482 | 68 | -414 |
| Projects.tsx | 289 | 96 | -193 |
| Works.tsx | 241 | 128 | -113 |
| Home.tsx | 199 | 100 | -99 |
| **New files** | 0 | 527 | +527 |
| **Net** | **2,095** | **1,138** | **-957** |

## Test plan

- [ ] Verify `npm run build` passes (TypeScript + Vite)
- [ ] Test all breakpoints: 360px, 768px, 960px, 1280px, 1340px, 1440px, 1801px+
- [ ] Verify Swiper carousel behavior: static cards on mobile, slidesPerView=1 on tablet, 2 on small desktop, 3 on xl
- [ ] Check desktop layout borders and section positioning
- [ ] Verify responsive transitions between breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)