### PR TITLE
refactor(gsap): Improve cursor visibility and reduced motion support

### DIFF
--- a/src/components/Cursor/index.tsx
+++ b/src/components/Cursor/index.tsx
@@ -49,9 +49,7 @@ export default function Cursor() {
       const isInteractive = target.closest("a") || target.closest("link") ||
         target.closest(".button") || target.closest(".work-card") || target.closest(".project-card");
 
-      if (cursor) {
-        cursor.style.display = isInteractive ? 'none' : 'inherit';
-      }
+      gsap.set(cursor, { autoAlpha: isInteractive ? 0 : 1 });
     };
 
     window.addEventListener("mousemove", onMouseMove, { passive: true });
@@ -63,7 +61,6 @@ export default function Cursor() {
     };
   }, {
     dependencies: [isMobileDevice],
-    scope: cursorRef,
     revertOnUpdate: true,
   });
 

--- a/src/components/SplashScreen/index.tsx
+++ b/src/components/SplashScreen/index.tsx
@@ -17,6 +17,7 @@ export default function SplashScreen() {
 	const { headerLogoRef, setSplashComplete, dismissSplash } = useSplash();
 	const splashLogoRef = useRef<HTMLHeadingElement>(null);
 	const overlayRef = useRef<HTMLDivElement>(null);
+	const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 	// Block scroll while splash is active
 	useEffect(() => {
@@ -27,6 +28,12 @@ export default function SplashScreen() {
 	}, []);
 
 	const handleAnimationComplete = useCallback(() => {
+		if (prefersReducedMotion) {
+			setSplashComplete();
+			dismissSplash();
+			return;
+		}
+
 		const splashLogo = splashLogoRef.current;
 		const headerTarget = headerLogoRef.current;
 		const overlay = overlayRef.current;
@@ -74,12 +81,13 @@ export default function SplashScreen() {
 				dismissSplash();
 			},
 		});
-	}, [headerLogoRef, setSplashComplete, dismissSplash]);
+	}, [headerLogoRef, setSplashComplete, dismissSplash, prefersReducedMotion]);
 
 	return (
 		<StyledSplashOverlay ref={overlayRef}>
 			<AsciiLogo
 				ref={splashLogoRef}
+				skipAnimation={prefersReducedMotion}
 				onAnimationComplete={handleAnimationComplete}
 			/>
 		</StyledSplashOverlay>


### PR DESCRIPTION
## Summary

- **Cursor visibility**: replace `cursor.style.display` with `gsap.set(cursor, { autoAlpha })` for smoother toggling (uses opacity + visibility instead of display: none)
- **Remove unnecessary scope**: remove `scope: cursorRef` from useGSAP config since no CSS selector queries are used
- **Reduced motion in SplashScreen**: detect `prefers-reduced-motion: reduce` and skip all GSAP animations — AsciiLogo shows final state immediately, SplashScreen transition completes instantly

## Test plan

- [ ] Verify `npm run build` passes
- [ ] Test cursor hides/shows smoothly when hovering interactive elements
- [ ] Enable "Reduce motion" in system settings → splash screen should complete instantly without animations
- [ ] Disable "Reduce motion" → splash screen glitch animation should play normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)