### PR TITLE
fix(ui): Resolve DOM warnings and invalid HTML nesting

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -9,14 +9,14 @@ import { ButtonProps } from "../../types";
 
 function Button(props: ButtonProps) {
 	const [isHovered, setIsHovered] = useState(false);
+	const isLink = !!props.url;
 
 	return (
 		<StyledButton
+			as={isLink ? "a" : "span"}
 			onMouseEnter={() => setIsHovered(true)}
 			onMouseLeave={() => setIsHovered(false)}
-			href={props.url}
-			target="_blank"
-			rel="noopener noreferrer"
+			{...(isLink ? { href: props.url, target: "_blank", rel: "noopener noreferrer" } : {})}
 			$isHovered={isHovered}
 			$p={props.p}
 			$m={props.m}

--- a/src/components/Containers/Skills.tsx
+++ b/src/components/Containers/Skills.tsx
@@ -13,7 +13,7 @@ import { skillsConfig } from "../../config/responsive";
 import { skillRows } from "../../data/skills";
 
 const StyledSkills = styled.section<{
-	flex?: number;
+	$flex?: number;
 }>`
 	width: 100%;
 	height: 100%;
@@ -30,7 +30,7 @@ const StyledSkills = styled.section<{
 			border: none;
 			border-left: 1px solid var(--secondary-60);
 			border-right: 1px solid var(--secondary-60);
-			flex: ${(props) => props.flex};
+			flex: ${(props) => props.$flex};
 		}
 	}
 `;
@@ -68,7 +68,7 @@ function Skills(props: SectionProps) {
 
 	if (cfg.titleOutside) {
 		return (
-			<StyledSkills flex={props.flex}>
+			<StyledSkills $flex={props.flex}>
 				<Text as="h2" variant={"subtitle-snd"} m={cfg.titleM}>
 					SKILLS & TOOLS
 				</Text>
@@ -89,7 +89,7 @@ function Skills(props: SectionProps) {
 	const needsIconWrapper = cfg.iconWrapperH != null;
 
 	return (
-		<StyledSkills flex={props.flex}>
+		<StyledSkills $flex={props.flex}>
 			<Container
 				w={cfg.outerW}
 				maxW={cfg.outerMaxW}

--- a/src/components/Containers/Works.tsx
+++ b/src/components/Containers/Works.tsx
@@ -16,7 +16,7 @@ import { worksConfig } from "../../config/responsive";
 import patternVector from "../../assets/vectors/pattern-vector.svg";
 
 const StyledWorks = styled.section<{
-	flex?: number;
+	$flex?: number;
 }>`
 	height: 100%;
 	display: flex;
@@ -47,6 +47,7 @@ const StyledWorks = styled.section<{
 		& {
 			border: none;
 			border-right: 1px solid var(--secondary-60);
+			flex: ${(props) => props.$flex};
 		}
 	}
 `;
@@ -57,7 +58,7 @@ function Works(props: SectionProps) {
 
 	if (cfg.titleOutside) {
 		return (
-			<StyledWorks flex={props.flex}>
+			<StyledWorks $flex={props.flex}>
 				<Container
 					h={"auto"}
 					w={cfg.outerW}
@@ -87,7 +88,7 @@ function Works(props: SectionProps) {
 	}
 
 	return (
-		<StyledWorks flex={props.flex}>
+		<StyledWorks $flex={props.flex}>
 			<Container
 				h={cfg.outerH}
 				w={cfg.outerW}

--- a/src/components/WorkCard/index.tsx
+++ b/src/components/WorkCard/index.tsx
@@ -81,7 +81,6 @@ function WorkCard(props: WorkCardProps) {
 						<Button
 							title={'Visit page'}
 							p={['0', '2', '0', '8']}
-							url={props.url}
 						>
 							<IconFrame src={arrowIcon} />
 						</Button>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,7 +62,7 @@ export type ProjectCardProps = {
 export type ButtonProps = {
 	children?: ReactNode;
 	title: string;
-	url: string;
+	url?: string;
 	p?: string[];
 	m?: string[];
 };


### PR DESCRIPTION
## Summary
- Use transient `$flex` prop in `StyledSkills` and `StyledWorks` to prevent styled-components from forwarding unknown props to the DOM
- Add missing `flex` CSS property to `StyledWorks` desktop media query (was declared but never applied)
- Make `Button` polymorphic: renders as `<span>` when no `url` is provided, fixing invalid `<a>` inside `<a>` nesting in `WorkCard`

## Test plan
- [x] `npm run build` passes
- [x] Playwright audit: 0 console errors, 0 warnings
- [x] Visual verification at 375px (mobile), 960px (tablet), 1920px (desktop)
- [ ] Verify Work cards still navigate correctly on click
- [ ] Verify standalone Buttons (outside WorkCard) still function as links

🤖 Generated with [Claude Code](https://claude.com/claude-code)