### PR TITLE
fix(noise-pattern): resolve 404 for noise texture in production

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -38,8 +38,8 @@
 	z-index: -1;
 	background-image: radial-gradient(circle, var(--secondary) 1px, transparent 1px);
 	background-size: 13.5px 13.5px;
-	-webkit-mask-image: url('/images/noise-texture.webp');
-	mask-image: url('/images/noise-texture.webp');
+	-webkit-mask-image: url('./assets/images/noise-texture.webp');
+	mask-image: url('./assets/images/noise-texture.webp');
 	-webkit-mask-size: 720px 720px;
 	mask-size: 720px 720px;
 	-webkit-mask-repeat: repeat;


### PR DESCRIPTION
## Summary
- `App.css` usaba `url('/images/noise-texture.webp')` apuntando a `public/images/`, que está excluido por la regla `public/*` en `.gitignore` → el archivo nunca se pushea → Vercel devuelve 404.
- Fix: cambiar a ruta relativa `url('./assets/images/noise-texture.webp')` para que Vite procese y hashee el asset desde `src/assets/` (mismo archivo ya trackeado en git que usa `mixins.ts`).

## Test plan
- [ ] `GET /assets/noise-texture-*.webp` responde 200 en producción
- [ ] El patrón de puntos (dot-grid animado) en `#root::before` se renderiza correctamente
- [ ] No hay regresión en el noise drift animation