### PR TITLE
release: fix noise-pattern 404 in production

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -38,8 +38,8 @@
 	z-index: -1;
 	background-image: radial-gradient(circle, var(--secondary) 1px, transparent 1px);
 	background-size: 13.5px 13.5px;
-	-webkit-mask-image: url('/images/noise-texture.webp');
-	mask-image: url('/images/noise-texture.webp');
+	-webkit-mask-image: url('./assets/images/noise-texture.webp');
+	mask-image: url('./assets/images/noise-texture.webp');
 	-webkit-mask-size: 720px 720px;
 	mask-size: 720px 720px;
 	-webkit-mask-repeat: repeat;


### PR DESCRIPTION
## Summary
Hotfix: noise-texture.webp devolvía 404 en producción porque `App.css` apuntaba a `/images/noise-texture.webp` (en `public/images/`, gitignored por `public/*`). Cambiado a ruta relativa que Vite procesa desde `src/assets/`.

## Test plan
- [ ] `#root::before` dot-grid visible en producción
- [ ] Network panel: sin 404 para noise-texture