### PR TITLE
feat(github-widget): animate contributions tooltip

### DIFF
--- a/src/components/Widget/GitHubWidget/index.tsx
+++ b/src/components/Widget/GitHubWidget/index.tsx
@@ -10,6 +10,10 @@ import {
 	StyledContributionGrid,
 	StyledSquare,
 	StyledContribTooltip,
+	StyledTooltipPositioner,
+	StyledTooltipDigitGroup,
+	StyledTooltipDigit,
+	StyledTooltipText,
 } from './styled';
 import { StyledWidgetHandle, StyledWidgetStat } from '../WidgetBase/styled';
 
@@ -190,11 +194,15 @@ function formatDateForA11y(dateStr: string): string {
 }
 
 interface TooltipState {
-	text: string;
+	count: number;
+	dateLabel: string;
 	x: number;
 	y: number;
 	position: 'top' | 'bottom';
 	align: 'start' | 'center' | 'end';
+	// Bumped on every hover so React remounts the inner tooltip and replays
+	// the entry animations even when the day-to-day position is identical.
+	key: number;
 }
 
 const tooltipTransform: Record<'top' | 'bottom', Record<'start' | 'center' | 'end', string>> = {
@@ -281,8 +289,15 @@ export default function GitHubWidget() {
 				? squareRect.top - wrapperRect.top
 				: squareRect.bottom - wrapperRect.top;
 
-			const text = `${day.count} contribution${day.count !== 1 ? 's' : ''} on ${formatDateDisplay(day.date)}`;
-			setTooltip({ text, x, y, position, align });
+			setTooltip((prev) => ({
+				count: day.count,
+				dateLabel: formatDateDisplay(day.date),
+				x,
+				y,
+				position,
+				align,
+				key: (prev?.key ?? 0) + 1,
+			}));
 		},
 		[actualWeeks]
 	);
@@ -354,17 +369,35 @@ export default function GitHubWidget() {
 						</StyledGridWithLabels>
 
 						{tooltip && (
-							<StyledContribTooltip
-								$position={tooltip.position}
-								$align={tooltip.align}
+							<StyledTooltipPositioner
 								style={{
 									left: tooltip.x,
 									top: tooltip.y,
 									transform: tooltipTransform[tooltip.position][tooltip.align],
 								}}
 							>
-								{tooltip.text}
-							</StyledContribTooltip>
+								<StyledContribTooltip
+									key={tooltip.key}
+									$position={tooltip.position}
+									$align={tooltip.align}
+								>
+									<StyledTooltipDigitGroup>
+										{String(tooltip.count)
+											.split('')
+											.map((digit, i) => (
+												<StyledTooltipDigit
+													key={`${tooltip.key}-${i}`}
+													style={{ animationDelay: `${i * 70}ms` }}
+												>
+													{digit}
+												</StyledTooltipDigit>
+											))}
+									</StyledTooltipDigitGroup>
+									<StyledTooltipText>
+										{` contribution${tooltip.count !== 1 ? 's' : ''} on ${tooltip.dateLabel}`}
+									</StyledTooltipText>
+								</StyledContribTooltip>
+							</StyledTooltipPositioner>
 						)}
 					</>
 				)}

--- a/src/components/Widget/GitHubWidget/styled.tsx
+++ b/src/components/Widget/GitHubWidget/styled.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { keyframes, css } from 'styled-components';
 import { tooltipBase } from '../../../styles/mixins';
 
 // Calendar wrapper — contains month labels, day labels, and contribution grid
@@ -94,11 +94,57 @@ const arrowAlignCss: Record<TooltipAlign, string> = {
 	end: 'right: 12px;',
 };
 
+// Origin where the modal scale anchors — paired with the arrow side so the
+// pop-in feels like it grows out of the square it points at.
+const originMap: Record<TooltipPosition, Record<TooltipAlign, string>> = {
+	top: {
+		start: 'bottom left',
+		center: 'bottom center',
+		end: 'bottom right',
+	},
+	bottom: {
+		start: 'top left',
+		center: 'top center',
+		end: 'top right',
+	},
+};
+
+const tooltipPopIn = keyframes`
+	0%   { transform: scale(0.96); opacity: 0; }
+	100% { transform: scale(1); opacity: 1; }
+`;
+
+const digitPopIn = keyframes`
+	0%   { transform: translateY(8px); opacity: 0; filter: blur(2px); }
+	100% { transform: translateY(0); opacity: 1; filter: blur(0); }
+`;
+
+const textSwapIn = keyframes`
+	0%   { transform: translateY(8px); opacity: 0; filter: blur(2px); }
+	100% { transform: translateY(0); opacity: 1; filter: blur(0); }
+`;
+
+// Wrapper that owns the absolute positioning (left/top + position translate).
+// Keeping the layout transform here lets the inner tooltip animate `scale`
+// cleanly without fighting the positioning translate.
+export const StyledTooltipPositioner = styled.div`
+	position: absolute;
+	z-index: var(--z-tooltip);
+	pointer-events: none;
+`;
+
 export const StyledContribTooltip = styled.div<{
 	$position: TooltipPosition;
 	$align: TooltipAlign;
 }>`
 	${tooltipBase}
+	position: relative;
+	transform-origin: ${(props) => originMap[props.$position][props.$align]};
+	animation: ${tooltipPopIn} 250ms cubic-bezier(0.22, 1, 0.36, 1) both;
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
 
 	&::before {
 		content: '';
@@ -109,4 +155,29 @@ export const StyledContribTooltip = styled.div<{
 				: `bottom: 100%; border-left: 5px solid transparent; border-right: 5px solid transparent; border-bottom: 5px solid var(--glass-border-start);`}
 		${(props) => arrowAlignCss[props.$align]}
 	}
+`;
+
+const reducedMotionReset = css`
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+`;
+
+export const StyledTooltipDigitGroup = styled.span`
+	display: inline-flex;
+	align-items: baseline;
+`;
+
+export const StyledTooltipDigit = styled.span`
+	display: inline-block;
+	will-change: transform, opacity, filter;
+	animation: ${digitPopIn} 500ms cubic-bezier(0.34, 1.45, 0.64, 1) both;
+	${reducedMotionReset}
+`;
+
+export const StyledTooltipText = styled.span`
+	display: inline-block;
+	will-change: transform, opacity, filter;
+	animation: ${textSwapIn} 200ms ease-out both;
+	${reducedMotionReset}
 `;


### PR DESCRIPTION
## Summary
Layer three independent entry animations on the GitHub contributions tooltip so they mix without fighting:

- **Container** scales 0.96 → 1 with opacity (250ms), `transform-origin` anchored to the arrow side — feels like it grows out of the square it points at.
- **Count digits** pop in individually with 70ms stagger (translateY + blur + opacity, 500ms soft-overshoot easing).
- **Description text** slides in from below with blur (200ms ease-out).

Position translate moved to a dedicated wrapper so it doesn't fight the scale animation. A `key` bumped on every hover replays the motion when moving between adjacent squares. All three respect `prefers-reduced-motion`.

## Test plan
- [ ] Hover GitHub contribution squares — tooltip pops in with combined motion
- [ ] Move between adjacent squares — animations replay each hover
- [ ] Multi-digit counts (e.g. 12, 105) stagger digits left-to-right
- [ ] System reduced-motion: no animation, tooltip just appears