### PR TITLE
feat(widgets): align Twitter & LinkedIn with shared digit-pop kit

### DIFF
--- a/src/components/Skeleton/LinkedInWidgetSkeleton.tsx
+++ b/src/components/Skeleton/LinkedInWidgetSkeleton.tsx
@@ -1,0 +1,108 @@
+import styled from 'styled-components';
+
+//* Shared
+import { shimmerSurface } from './shimmer';
+
+const StyledRoot = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--8);
+	height: 100%;
+`;
+
+const StyledHandleSk = styled.div`
+	height: 12px;
+	width: 35%;
+	border-radius: var(--radius-sm);
+	${shimmerSurface}
+`;
+
+const StyledPositionSk = styled.div`
+	height: 14px;
+	width: 70%;
+	border-radius: var(--radius-sm);
+	${shimmerSurface}
+`;
+
+const StyledLocationSk = styled.div`
+	height: 12px;
+	width: 30%;
+	border-radius: var(--radius-sm);
+	${shimmerSurface}
+`;
+
+const StyledSectionLabelSk = styled.div`
+	height: 10px;
+	width: 25%;
+	border-radius: var(--radius-sm);
+	margin-top: var(--4);
+	${shimmerSurface}
+`;
+
+const StyledExperienceList = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--6);
+`;
+
+const StyledExperienceRow = styled.div`
+	display: flex;
+	align-items: flex-start;
+	gap: var(--8);
+	padding-left: var(--6);
+	border-left: 1px solid var(--glass-border-start);
+`;
+
+const StyledLogoSk = styled.div`
+	width: 28px;
+	height: 28px;
+	border-radius: var(--radius-sm);
+	flex-shrink: 0;
+	${shimmerSurface}
+`;
+
+const StyledExpContent = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--2);
+	flex: 1;
+	min-width: 0;
+`;
+
+const StyledTitleSk = styled.div`
+	height: 12px;
+	width: 75%;
+	border-radius: var(--radius-sm);
+	${shimmerSurface}
+`;
+
+const StyledPeriodSk = styled.div`
+	height: 10px;
+	width: 45%;
+	border-radius: var(--radius-sm);
+	${shimmerSurface}
+`;
+
+function LinkedInWidgetSkeleton() {
+	return (
+		<StyledRoot>
+			<StyledHandleSk />
+			<StyledPositionSk />
+			<StyledLocationSk />
+			<StyledSectionLabelSk />
+			<StyledExperienceList>
+				{Array.from({ length: 3 }).map((_, i) => (
+					<StyledExperienceRow key={i}>
+						<StyledLogoSk />
+						<StyledExpContent>
+							<StyledTitleSk />
+							<StyledPeriodSk />
+						</StyledExpContent>
+					</StyledExperienceRow>
+				))}
+			</StyledExperienceList>
+		</StyledRoot>
+	);
+}
+
+export default LinkedInWidgetSkeleton;

--- a/src/components/Widget/GitHubWidget/index.tsx
+++ b/src/components/Widget/GitHubWidget/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 
 //* Styled
 import {
@@ -11,10 +12,15 @@ import {
 	StyledSquare,
 	StyledContribTooltip,
 	StyledTooltipPositioner,
-	StyledDigitGroup,
-	StyledDigit,
+	StyledLegend,
+	StyledLegendSwatchRow,
+	StyledLegendSwatch,
+	StyledFooterLabel,
+	StyledTotalLabel,
 } from './styled';
-import { StyledWidgetHandle, StyledWidgetStat } from '../WidgetBase/styled';
+import { useTooltipSwap } from '../shared/digitPop';
+import DigitGroup from '../shared/DigitGroup';
+import { StyledWidgetHandle } from '../WidgetBase/styled';
 
 //* Components
 import WidgetBase from '../WidgetBase';
@@ -199,22 +205,6 @@ interface TooltipPlacement {
 }
 
 const TOOLTIP_CLOSE_DUR = 150;
-const DIGIT_STAGGER_MS = 70;
-
-// Tracks one piece of dynamic content. The replay animation lives on the
-// rendered <StyledDigitGroup> via React `key` — when `displayed` changes,
-// the keyed element remounts and the digit pop-in keyframe runs again.
-function useTooltipSwap<T>() {
-	const [displayed, setDisplayedState] = useState<T | null>(null);
-	const valueRef = useRef<T | null>(null);
-
-	const setValue = useCallback((next: T | null) => {
-		setDisplayedState(next);
-		valueRef.current = next;
-	}, []);
-
-	return { displayed, setValue, valueRef };
-}
 
 const tooltipTransform: Record<'top' | 'bottom', Record<'start' | 'center' | 'end', string>> = {
 	top: {
@@ -229,29 +219,17 @@ const tooltipTransform: Record<'top' | 'bottom', Record<'start' | 'center' | 'en
 	},
 };
 
-// Splits a value into per-character spans so each one runs the digit pop-in
-// with a staggered animation-delay. Keying the wrapper by the value means React
-// remounts it on change, replaying the keyframe animation for the new content.
-function renderDigits(value: string | number | null, prefix: string) {
-	const text = value != null ? String(value) : '';
-	return (
-		<StyledDigitGroup key={`${prefix}-${text}`}>
-			{text.split('').map((char, i) => (
-				<StyledDigit key={i} style={{ animationDelay: `${i * DIGIT_STAGGER_MS}ms` }}>
-					{char}
-				</StyledDigit>
-			))}
-		</StyledDigitGroup>
-	);
-}
-
 const isTouchDevice =
 	typeof window !== 'undefined' &&
 	window.matchMedia('(hover: none) and (pointer: coarse)').matches;
 
 const CURRENT_YEAR = new Date().getFullYear();
 
+const LEGEND_LEVELS = [0, 1, 2, 3, 4] as const;
+
 export default function GitHubWidget() {
+	const { t } = useTranslation('home');
+
 	const {
 		contributions,
 		totalContributions,
@@ -392,11 +370,26 @@ export default function GitHubWidget() {
 			loading={loading}
 			error={error}
 			skeleton={<GitHubWidgetSkeleton />}
+			footer={
+				<>
+					<StyledLegend aria-hidden="true">
+						<StyledFooterLabel>{t('activity.github.legendLess')}</StyledFooterLabel>
+						<StyledLegendSwatchRow>
+							{LEGEND_LEVELS.map((level) => (
+								<StyledLegendSwatch key={level} $level={level} />
+							))}
+						</StyledLegendSwatchRow>
+						<StyledFooterLabel>{t('activity.github.legendMore')}</StyledFooterLabel>
+					</StyledLegend>
+					<StyledTotalLabel>
+						{t('activity.github.totalThisYear', {
+							total: totalContributions.toLocaleString(),
+						})}
+					</StyledTotalLabel>
+				</>
+			}
 		>
 			<StyledWidgetHandle>@{GITHUB_USERNAME}</StyledWidgetHandle>
-			<StyledWidgetStat>
-				{totalContributions.toLocaleString()} contributions in {CURRENT_YEAR}
-			</StyledWidgetStat>
 
 			<StyledCalendarWrapper ref={wrapperRef}>
 				{actualWeeks > 0 && (
@@ -459,11 +452,20 @@ export default function GitHubWidget() {
 									$align={placement.align}
 									$visible={isOpen}
 								>
-									{renderDigits(countSwap.displayed, 'count')}
+									<DigitGroup
+										key={`count-${countSwap.displayed ?? ''}`}
+										value={countSwap.displayed}
+									/>
 									{' contributions on '}
-									{renderDigits(monthDaySwap.displayed, 'md')}
+									<DigitGroup
+										key={`md-${monthDaySwap.displayed ?? ''}`}
+										value={monthDaySwap.displayed}
+									/>
 									{', '}
-									{renderDigits(yearSwap.displayed, 'year')}
+									<DigitGroup
+										key={`year-${yearSwap.displayed ?? ''}`}
+										value={yearSwap.displayed}
+									/>
 								</StyledContribTooltip>
 							</StyledTooltipPositioner>
 						)}

--- a/src/components/Widget/GitHubWidget/styled.tsx
+++ b/src/components/Widget/GitHubWidget/styled.tsx
@@ -1,4 +1,4 @@
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 import { tooltipBase } from '../../../styles/mixins';
 
 // Calendar wrapper — contains month labels, day labels, and contribution grid
@@ -84,6 +84,44 @@ export const StyledSquare = styled.div<{ $level: 0 | 1 | 2 | 3 | 4; $radius: num
 	}
 `;
 
+// GitHub-style legend.
+export const StyledLegend = styled.div`
+	display: flex;
+	align-items: center;
+	gap: var(--6);
+`;
+
+export const StyledLegendSwatchRow = styled.span`
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+`;
+
+export const StyledLegendSwatch = styled.span<{ $level: 0 | 1 | 2 | 3 | 4 }>`
+	width: 10px;
+	height: 10px;
+	border-radius: 2px;
+	background-color: ${(props) => CONTRIB_LEVELS[props.$level]};
+	border: 1px solid var(--glass-border-start);
+`;
+
+export const StyledFooterLabel = styled.span`
+	font-family: var(--font-geist-pixel-circle);
+	font-size: var(--font-size-label);
+	line-height: 1;
+	color: var(--text);
+	opacity: var(--opacity-soft);
+`;
+
+export const StyledTotalLabel = styled.span`
+	font-family: var(--font-geist-pixel-circle);
+	font-size: var(--font-size-label);
+	line-height: 1;
+	color: var(--text);
+	opacity: var(--opacity-muted);
+	text-align: right;
+`;
+
 // Contribution tooltip — positioned absolutely within CalendarWrapper
 type TooltipAlign = 'start' | 'center' | 'end';
 type TooltipPosition = 'top' | 'bottom';
@@ -159,35 +197,3 @@ export const StyledContribTooltip = styled.div<{
 	}
 `;
 
-// Per-character pop-in: each digit slides up from below with a blur fade,
-// staggered via animation-delay set inline. The wrapping element is keyed by
-// its current value, so React remounts it on change and the animation replays
-// from scratch (matches the user-supplied "Number pop-in" pattern).
-const digitPopIn = keyframes`
-	0% {
-		transform: translateY(8px);
-		opacity: 0;
-		filter: blur(2px);
-	}
-	100% {
-		transform: translateY(0);
-		opacity: 1;
-		filter: blur(0);
-	}
-`;
-
-export const StyledDigitGroup = styled.span`
-	display: inline-flex;
-	align-items: baseline;
-`;
-
-export const StyledDigit = styled.span`
-	display: inline-block;
-	white-space: pre;
-	will-change: transform, opacity, filter;
-	animation: ${digitPopIn} 500ms cubic-bezier(0.34, 1.45, 0.64, 1) both;
-
-	@media (prefers-reduced-motion: reduce) {
-		animation: none;
-	}
-`;

--- a/src/components/Widget/LinkedInWidget/index.tsx
+++ b/src/components/Widget/LinkedInWidget/index.tsx
@@ -1,8 +1,11 @@
+import { useTranslation } from 'react-i18next';
+
 //? Hooks
 import { useTheme } from '../../../hooks/useTheme';
 
 //* Components
 import WidgetBase from '../WidgetBase';
+import LinkedInWidgetSkeleton from '../../Skeleton/LinkedInWidgetSkeleton';
 import Text from '../../Text';
 
 //* Styled
@@ -18,7 +21,12 @@ import {
 	StyledExperienceTitle,
 	StyledExperiencePeriod,
 	StyledCurrentBadge,
+	StyledFooterLabel,
+	StyledFooterMeta,
 } from './styled';
+
+//* Shared
+import { POP_IN_STAGGER_MS } from '../shared/digitPop';
 
 //* Icon registry
 import { iconRegistry } from '../../Icon';
@@ -28,8 +36,10 @@ import { LINKEDIN_URL } from '../../../data/socialFeed';
 import { linkedinProfile } from '../../../data/staticSocial';
 
 const visibleExperience = linkedinProfile.experience?.slice(0, 4);
+const totalPositions = linkedinProfile.experience?.length ?? 0;
 
 export default function LinkedInWidget() {
+	const { t } = useTranslation('home');
 	const { isDarkMode } = useTheme();
 
 	return (
@@ -37,6 +47,23 @@ export default function LinkedInWidget() {
 			icon={iconRegistry.linkedin}
 			platformName="LinkedIn"
 			profileUrl={LINKEDIN_URL}
+			skeleton={<LinkedInWidgetSkeleton />}
+			footer={
+				totalPositions > 0
+					? (
+						<>
+							{linkedinProfile.location && (
+								<StyledFooterLabel>
+									{t('activity.linkedin.basedIn', { location: linkedinProfile.location })}
+								</StyledFooterLabel>
+							)}
+							<StyledFooterMeta>
+								{t('activity.linkedin.positionsCount', { count: totalPositions })}
+							</StyledFooterMeta>
+						</>
+					)
+					: undefined
+			}
 		>
 			<StyledProfileInfo>
 				<Text as="span" variant="subtitle-sm">
@@ -52,11 +79,12 @@ export default function LinkedInWidget() {
 				)}
 				{visibleExperience && visibleExperience.length > 0 && (
 					<>
-						<StyledSectionLabel>Experience</StyledSectionLabel>
+						<StyledSectionLabel>{t('activity.linkedin.experience')}</StyledSectionLabel>
 						<StyledExperienceList>
-							{visibleExperience.map((exp) => (
+							{visibleExperience.map((exp, i) => (
 								<StyledExperienceItem
 									key={`${exp.company}-${exp.title}`}
+									style={{ animationDelay: `${i * POP_IN_STAGGER_MS}ms` }}
 								>
 									{(exp.companyLogo || exp.companyLogoLight) && (
 										<StyledCompanyLogo
@@ -69,7 +97,7 @@ export default function LinkedInWidget() {
 											{exp.title} @ {exp.company}
 											{exp.current && (
 												<StyledCurrentBadge>
-													Current
+													{t('activity.linkedin.currentBadge')}
 												</StyledCurrentBadge>
 											)}
 										</StyledExperienceTitle>

--- a/src/components/Widget/LinkedInWidget/styled.tsx
+++ b/src/components/Widget/LinkedInWidget/styled.tsx
@@ -1,5 +1,6 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import { widgetText } from '../../../styles/mixins';
+import { popInAnimation } from '../shared/digitPop';
 
 export const StyledProfileInfo = styled.div`
 	display: flex;
@@ -62,6 +63,8 @@ export const StyledExperienceItem = styled.div`
 	gap: var(--8);
 	padding-left: var(--6);
 	border-left: 1px solid var(--glass-border-start);
+	will-change: transform, opacity, filter;
+	${popInAnimation}
 `;
 
 export const StyledCompanyLogo = styled.img`
@@ -91,6 +94,13 @@ export const StyledExperiencePeriod = styled.span`
 	${widgetText('0.625rem', 'var(--opacity-muted)')}
 `;
 
+// Subtle "live" pulse on the Current badge — opacity-only so the layout
+// doesn't reflow and the GPU compositor keeps it smooth.
+const livePulse = keyframes`
+	0%, 100% { opacity: 1; }
+	50%      { opacity: 0.6; }
+`;
+
 export const StyledCurrentBadge = styled.span`
 	display: inline-flex;
 	align-items: center;
@@ -102,4 +112,26 @@ export const StyledCurrentBadge = styled.span`
 	line-height: 1;
 	color: var(--background);
 	font-weight: 600;
+	animation: ${livePulse} 2.4s ease-in-out infinite;
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+`;
+
+export const StyledFooterLabel = styled.span`
+	font-family: var(--font-geist-pixel-circle);
+	font-size: var(--font-size-label);
+	line-height: 1;
+	color: var(--text);
+	opacity: var(--opacity-soft);
+`;
+
+export const StyledFooterMeta = styled.span`
+	font-family: var(--font-geist-pixel-circle);
+	font-size: var(--font-size-label);
+	line-height: 1;
+	color: var(--text);
+	opacity: var(--opacity-muted);
+	text-align: right;
 `;

--- a/src/components/Widget/TwitterWidget/index.tsx
+++ b/src/components/Widget/TwitterWidget/index.tsx
@@ -1,3 +1,6 @@
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
+
 //* Components
 import WidgetBase from '../WidgetBase';
 import TwitterWidgetSkeleton from '../../Skeleton/TwitterWidgetSkeleton';
@@ -11,8 +14,13 @@ import {
 	StyledTweetText,
 	StyledTweetMeta,
 	StyledTweetStat,
+	StyledFooterLabel,
+	StyledFooterMeta,
 } from './styled';
-import { StyledWidgetHandle, StyledWidgetStat } from '../WidgetBase/styled';
+import { StyledWidgetHandle } from '../WidgetBase/styled';
+
+//* Shared
+import { POP_IN_STAGGER_MS } from '../shared/digitPop';
 
 //* Icon registry
 import { iconRegistry } from '../../Icon';
@@ -37,31 +45,33 @@ function ClockSvg() {
 	);
 }
 
-const formatDateCache = new Map<string, string>();
-function formatDate(dateStr: string): string {
-	const cached = formatDateCache.get(dateStr);
-	if (cached) return cached;
-
+function getRelativeTimeKey(dateStr: string): { key: string; count: number } {
 	const date = new Date(dateStr);
 	const now = new Date();
-	const diffMs = now.getTime() - date.getTime();
-	const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+	const diffDays = Math.floor((now.getTime() - date.getTime()) / 86400000);
 
-	let result: string;
-	if (diffDays === 0) result = 'today';
-	else if (diffDays === 1) result = '1d ago';
-	else if (diffDays < 30) result = `${diffDays}d ago`;
-	else if (diffDays < 365) result = `${Math.floor(diffDays / 30)}mo ago`;
-	else result = `${Math.floor(diffDays / 365)}y ago`;
+	if (diffDays <= 0) return { key: 'today', count: 0 };
+	if (diffDays === 1) return { key: 'oneDay', count: 1 };
+	if (diffDays < 30) return { key: 'daysAgo', count: diffDays };
+	if (diffDays < 365) return { key: 'monthsAgo', count: Math.floor(diffDays / 30) };
+	return { key: 'yearsAgo', count: Math.floor(diffDays / 365) };
+}
 
-	formatDateCache.set(dateStr, result);
-	return result;
+function formatRelativeTime(t: TFunction<'home'>, dateStr: string): string {
+	const { key, count } = getRelativeTimeKey(dateStr);
+	return t(`activity.twitter.timeAgo.${key}`, { count });
 }
 
 export default function TwitterWidget() {
+	const { t } = useTranslation('home');
 	const { tweets, loading, error } = useTweets();
 	const { isDarkMode } = useTheme();
 	const profileImg = isDarkMode ? profileDark : profileLight;
+
+	const visibleTweets = tweets.slice(0, 3);
+	const lastActivity = visibleTweets[0]
+		? formatRelativeTime(t, visibleTweets[0].date)
+		: null;
 
 	return (
 		<WidgetBase
@@ -71,17 +81,33 @@ export default function TwitterWidget() {
 			loading={loading}
 			error={error}
 			skeleton={<TwitterWidgetSkeleton />}
+			footer={
+				visibleTweets.length > 0
+					? (
+						<>
+							<StyledFooterLabel>
+								{t('activity.twitter.recentCount', { count: visibleTweets.length })}
+							</StyledFooterLabel>
+							{lastActivity && (
+								<StyledFooterMeta>
+									{t('activity.twitter.lastActivity', { time: lastActivity })}
+								</StyledFooterMeta>
+							)}
+						</>
+					)
+					: undefined
+			}
 		>
 			<StyledWidgetHandle>{TWITTER_HANDLE}</StyledWidgetHandle>
-			<StyledWidgetStat>~100 posts</StyledWidgetStat>
 
 			<StyledTweetList>
-				{tweets.slice(0, 3).map((tweet) => (
+				{visibleTweets.map((tweet, i) => (
 					<StyledTweetItem
 						key={tweet.id}
 						href={tweet.url}
 						target="_blank"
 						rel="noopener noreferrer"
+						style={{ animationDelay: `${i * POP_IN_STAGGER_MS}ms` }}
 					>
 						<StyledTweetThumbnail>
 							<img src={profileImg} alt="Tobias Facello" loading="lazy" />
@@ -91,7 +117,7 @@ export default function TwitterWidget() {
 							<StyledTweetMeta>
 								<StyledTweetStat>
 									<ClockSvg />
-									{formatDate(tweet.date)}
+									{formatRelativeTime(t, tweet.date)}
 								</StyledTweetStat>
 							</StyledTweetMeta>
 						</StyledTweetContent>

--- a/src/components/Widget/TwitterWidget/styled.tsx
+++ b/src/components/Widget/TwitterWidget/styled.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { popInAnimation } from '../shared/digitPop';
 
 export const StyledTweetList = styled.div`
 	display: flex;
@@ -69,6 +70,8 @@ export const StyledTweetItem = styled.a`
 	border-radius: var(--radius-sm);
 	text-decoration: none;
 	color: inherit;
+	will-change: transform, opacity, filter;
+	${popInAnimation}
 	transition:
 		background-color var(--transition-fast),
 		transform var(--transition-fast);
@@ -82,6 +85,23 @@ export const StyledTweetItem = styled.a`
 			opacity: 1;
 		}
 	}
+`;
+
+export const StyledFooterLabel = styled.span`
+	font-family: var(--font-geist-pixel-circle);
+	font-size: var(--font-size-label);
+	line-height: 1;
+	color: var(--text);
+	opacity: var(--opacity-soft);
+`;
+
+export const StyledFooterMeta = styled.span`
+	font-family: var(--font-geist-pixel-circle);
+	font-size: var(--font-size-label);
+	line-height: 1;
+	color: var(--text);
+	opacity: var(--opacity-muted);
+	text-align: right;
 `;
 
 export const StyledTweetMeta = styled.div`

--- a/src/components/Widget/WidgetBase/index.tsx
+++ b/src/components/Widget/WidgetBase/index.tsx
@@ -14,6 +14,7 @@ import {
 	StyledWidgetIcon,
 	StyledWidgetContent,
 	StyledErrorState,
+	StyledWidgetFooter,
 } from './styled';
 
 type WidgetBaseProps = {
@@ -25,6 +26,7 @@ type WidgetBaseProps = {
 	error?: string | null;
 	onRetry?: () => void;
 	skeleton?: ReactNode;
+	footer?: ReactNode;
 };
 
 export default function WidgetBase(props: WidgetBaseProps) {
@@ -66,7 +68,10 @@ export default function WidgetBase(props: WidgetBaseProps) {
 						)}
 					</StyledErrorState>
 				) : (
-					props.children
+					<>
+						{props.children}
+						{props.footer && <StyledWidgetFooter>{props.footer}</StyledWidgetFooter>}
+					</>
 				)}
 			</StyledWidgetContent>
 		</StyledWidgetCard>

--- a/src/components/Widget/WidgetBase/styled.tsx
+++ b/src/components/Widget/WidgetBase/styled.tsx
@@ -80,3 +80,15 @@ export const StyledErrorState = styled.div`
 	gap: var(--12);
 	flex: 1;
 `;
+
+// Footer slot — anchored to the widget bottom via margin-top: auto, with
+// space-between so a left stat and a right stat read as a balanced pair.
+export const StyledWidgetFooter = styled.div`
+	margin-top: auto;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--12);
+	flex-wrap: wrap;
+	padding-top: var(--6);
+`;

--- a/src/components/Widget/shared/DigitGroup.tsx
+++ b/src/components/Widget/shared/DigitGroup.tsx
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+import { POP_IN_STAGGER_MS, popInAnimation } from './digitPop';
+
+const StyledDigitGroup = styled.span`
+	display: inline-flex;
+	align-items: baseline;
+`;
+
+const StyledDigit = styled.span`
+	display: inline-block;
+	white-space: pre;
+	will-change: transform, opacity, filter;
+	${popInAnimation}
+`;
+
+type DigitGroupProps = {
+	value: string | number | null;
+};
+
+// Splits a value into per-character spans, each running the digit pop-in
+// keyframe with a staggered animation-delay. Keying this component at the
+// call site (`<DigitGroup key={value} ... />`) triggers React to remount it
+// when the value changes, replaying the animation for the new content.
+function DigitGroup({ value }: DigitGroupProps) {
+	const text = value != null ? String(value) : '';
+	return (
+		<StyledDigitGroup>
+			{text.split('').map((char, i) => (
+				<StyledDigit
+					key={i}
+					style={{ animationDelay: `${i * POP_IN_STAGGER_MS}ms` }}
+				>
+					{char}
+				</StyledDigit>
+			))}
+		</StyledDigitGroup>
+	);
+}
+
+export default DigitGroup;

--- a/src/components/Widget/shared/digitPop.ts
+++ b/src/components/Widget/shared/digitPop.ts
@@ -1,0 +1,36 @@
+import { useState, useRef, useCallback } from 'react';
+import { css, keyframes } from 'styled-components';
+
+export const POP_IN_DUR_MS = 500;
+export const POP_IN_STAGGER_MS = 70;
+
+// Shared "translateY 8px → 0 + blur 2px → 0 + opacity 0 → 1" entry.
+// Used both per-character on numeric values (digit pop-in) and per-row on
+// staggered list items across widgets.
+export const popInFromBelow = keyframes`
+	0%   { transform: translateY(8px); opacity: 0; filter: blur(2px); }
+	100% { transform: translateY(0); opacity: 1; filter: blur(0); }
+`;
+
+export const popInAnimation = css`
+	animation: ${popInFromBelow} ${POP_IN_DUR_MS}ms cubic-bezier(0.34, 1.45, 0.64, 1) both;
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+`;
+
+// Per-field swap controller: tracks the displayed value and exposes a setter
+// that updates state and ref atomically, so handlers can compare prev vs new
+// synchronously without waiting for a render.
+export function useTooltipSwap<T>() {
+	const [displayed, setDisplayedState] = useState<T | null>(null);
+	const valueRef = useRef<T | null>(null);
+
+	const setValue = useCallback((next: T | null) => {
+		setDisplayedState(next);
+		valueRef.current = next;
+	}, []);
+
+	return { displayed, setValue, valueRef };
+}

--- a/src/data/tweets.json
+++ b/src/data/tweets.json
@@ -1,23 +1,72 @@
 [
 	{
-		"id": "2026005468682883396",
-		"text": "Deleted an 8K+ element SVG file and wrote one line of CSS instead. Replicated the exact same dot pattern at zero byte cost — no file to fetch, no DOM to parse, no SVG engine overhead. Pure CSS and pure performance.The original breakdown made by @JohnPhamous 👇🏻",
-		"date": "2026-02-23",
+		"id": "2049231490127475047",
+		"text": "El dichoso 1% 🤌🏻",
+		"date": "2026-04-28",
 		"authorName": "Fache 🧉",
-		"url": "https://twitter.com/fachebits/status/2026005468682883396"
+		"url": "https://twitter.com/fachebits/status/2049231490127475047"
 	},
 	{
-		"id": "2024330494028968232",
-		"text": "I was here 🎂",
-		"date": "2026-02-19",
+		"id": "2049156587760095249",
+		"text": "Yendo a integrarlo 🤳🏻",
+		"date": "2026-04-28",
 		"authorName": "Fache 🧉",
-		"url": "https://twitter.com/fachebits/status/2024330494028968232"
+		"url": "https://twitter.com/fachebits/status/2049156587760095249"
 	},
 	{
-		"id": "2023261074343047652",
-		"text": "✲ Sudo-ing without understanding…",
-		"date": "2026-02-16",
+		"id": "2048847675827663104",
+		"text": "AfeitAir quizás?",
+		"date": "2026-04-27",
 		"authorName": "Fache 🧉",
-		"url": "https://twitter.com/fachebits/status/2023261074343047652"
+		"url": "https://twitter.com/fachebits/status/2048847675827663104"
+	},
+	{
+		"id": "2048037422718411150",
+		"text": "Buen arranque de la hackathon, a shippear 🚀\n\n@v0 @crecimientoar\n\n#ZeroToAgent",
+		"date": "2026-04-25",
+		"authorName": "Fache 🧉",
+		"url": "https://twitter.com/fachebits/status/2048037422718411150"
+	},
+	{
+		"id": "2047646740371636667",
+		"text": "El concepto de Design Engineering se hace más fuerte en un momento donde ~80% del código lo escribe la AI.\n\nMás código se genera, más valor tiene el tiempo invertido en el último 5%.\n\nEse 5% es el que hace que un producto se sienta premium o barato. Y por ahora es 100% humano.",
+		"date": "2026-04-24",
+		"authorName": "Fache 🧉",
+		"url": "https://twitter.com/fachebits/status/2047646740371636667"
+	},
+	{
+		"id": "2047455641552220248",
+		"text": "Participar de mi primer hackathon y encima de Vercel. Soñado 🙏🏼🚀✨",
+		"date": "2026-04-23",
+		"authorName": "Fache 🧉",
+		"url": "https://twitter.com/fachebits/status/2047455641552220248"
+	},
+	{
+		"id": "2047305306275811790",
+		"text": "Hora de empezar a usar HyperFrames para contenido",
+		"date": "2026-04-23",
+		"authorName": "Fache 🧉",
+		"url": "https://twitter.com/fachebits/status/2047305306275811790"
+	},
+	{
+		"id": "2046899995983446271",
+		"text": "Probably the best part of it, is that you are into it after 5~ minutes of setting up. That's it. 🚀",
+		"date": "2026-04-22",
+		"authorName": "Fache 🧉",
+		"url": "https://twitter.com/fachebits/status/2046899995983446271"
+	},
+	{
+		"id": "2046897093122396302",
+		"text": "Bastante straightforward, me gusta che...",
+		"date": "2026-04-22",
+		"authorName": "Fache 🧉",
+		"url": "https://twitter.com/fachebits/status/2046897093122396302"
+	},
+	{
+		"id": "2046891872338022639",
+		"text": "Me parece excelente para matar el FOMO diario y recuperar lo realmente relevante día a día. Habrá que probarlo 👌🏻",
+		"date": "2026-04-22",
+		"authorName": "Fache 🧉",
+		"url": "https://twitter.com/fachebits/status/2046891872338022639"
 	}
 ]

--- a/src/i18n/locales/en/home.json
+++ b/src/i18n/locales/en/home.json
@@ -31,13 +31,29 @@
 		"error": "Unable to load data",
 		"github": {
 			"repos": "Repositories",
-			"followers": "Followers"
+			"followers": "Followers",
+			"legendLess": "Less",
+			"legendMore": "More",
+			"totalThisYear": "{{total}} contributions total this year"
 		},
 		"twitter": {
-			"followOn": "Follow on X"
+			"followOn": "Follow on X",
+			"recentCount": "{{count}} recent posts",
+			"lastActivity": "Last posted {{time}}",
+			"timeAgo": {
+				"today": "today",
+				"oneDay": "1d ago",
+				"daysAgo": "{{count}}d ago",
+				"monthsAgo": "{{count}}mo ago",
+				"yearsAgo": "{{count}}y ago"
+			}
 		},
 		"linkedin": {
-			"connectOn": "Connect on LinkedIn"
+			"connectOn": "Connect on LinkedIn",
+			"experience": "Experience",
+			"currentBadge": "Current",
+			"positionsCount": "{{count}} positions",
+			"basedIn": "Based in {{location}}"
 		}
 	},
 	"blog": {

--- a/src/i18n/locales/es/home.json
+++ b/src/i18n/locales/es/home.json
@@ -31,13 +31,29 @@
 		"error": "No se pudo cargar la información",
 		"github": {
 			"repos": "Repositorios",
-			"followers": "Seguidores"
+			"followers": "Seguidores",
+			"legendLess": "Menos",
+			"legendMore": "Más",
+			"totalThisYear": "{{total}} contribuciones en lo que va del año"
 		},
 		"twitter": {
-			"followOn": "Seguir en X"
+			"followOn": "Seguir en X",
+			"recentCount": "{{count}} posts recientes",
+			"lastActivity": "Último post {{time}}",
+			"timeAgo": {
+				"today": "hoy",
+				"oneDay": "hace 1d",
+				"daysAgo": "hace {{count}}d",
+				"monthsAgo": "hace {{count}}m",
+				"yearsAgo": "hace {{count}}a"
+			}
 		},
 		"linkedin": {
-			"connectOn": "Conectar en LinkedIn"
+			"connectOn": "Conectar en LinkedIn",
+			"experience": "Experiencia",
+			"currentBadge": "Actual",
+			"positionsCount": "{{count}} posiciones",
+			"basedIn": "Desde {{location}}"
 		}
 	},
 	"blog": {

--- a/src/i18n/locales/pt/home.json
+++ b/src/i18n/locales/pt/home.json
@@ -31,13 +31,29 @@
 		"error": "Não foi possível carregar os dados",
 		"github": {
 			"repos": "Repositórios",
-			"followers": "Seguidores"
+			"followers": "Seguidores",
+			"legendLess": "Menos",
+			"legendMore": "Mais",
+			"totalThisYear": "{{total}} contribuições no ano até agora"
 		},
 		"twitter": {
-			"followOn": "Seguir no X"
+			"followOn": "Seguir no X",
+			"recentCount": "{{count}} posts recentes",
+			"lastActivity": "Último post {{time}}",
+			"timeAgo": {
+				"today": "hoje",
+				"oneDay": "1d atrás",
+				"daysAgo": "{{count}}d atrás",
+				"monthsAgo": "{{count}}m atrás",
+				"yearsAgo": "{{count}}a atrás"
+			}
 		},
 		"linkedin": {
-			"connectOn": "Conectar no LinkedIn"
+			"connectOn": "Conectar no LinkedIn",
+			"experience": "Experiência",
+			"currentBadge": "Atual",
+			"positionsCount": "{{count}} posições",
+			"basedIn": "Em {{location}}"
 		}
 	},
 	"blog": {


### PR DESCRIPTION
## Summary
Generalize the GitHub widget refactor into a shared kit and apply it across Twitter and LinkedIn.

**Shared kit (`src/components/Widget/shared`)**
- `digitPop.ts`: `popInFromBelow` keyframe + `popInAnimation` css mixin + `useTooltipSwap` hook.
- `DigitGroup.tsx`: per-character render component (replays via React `key`).
- `WidgetBase` gets a `footer` slot anchored with `margin-top: auto`.

**GitHubWidget**
- Footer migrated to the shared `WidgetBase` slot.
- Imports `DigitGroup` + `useTooltipSwap` from shared.

**TwitterWidget**
- Removed placeholder `~100 posts`; new footer with `recentCount` (left) and `lastActivity` (right).
- `formatDate` → `formatRelativeTime` backed by `activity.twitter.timeAgo.*` (es/en/pt).
- Tweet items stagger with 70ms delay using `popInAnimation`.
- Refreshed `src/data/tweets.json` with latest fetched tweets.

**LinkedInWidget**
- i18n labels (`activity.linkedin.experience`, `currentBadge`, `positionsCount`, `basedIn`).
- Experience rows stagger.
- Current badge: subtle 2.4s opacity pulse as a live indicator.
- Footer: location (left), positions count (right).
- New dedicated `LinkedInWidgetSkeleton`.

## Test plan
- [ ] GitHub widget renders identical to before; footer slot works the same.
- [ ] Twitter widget shows new footer with translated `lastActivity` across es/en/pt.
- [ ] Twitter tweet rows stagger on first paint after data loads.
- [ ] LinkedIn: experience rows stagger, Current badge pulses, footer reads "Based in Argentina · 3 positions".
- [ ] LinkedIn: skeleton silhouette matches layout.
- [ ] Reduced motion: no pulse, no stagger, no popIn.