### PR TITLE
refactor(carousel): smoother Swiper autoplay transitions

### DIFF
--- a/src/components/WorkCardsCarousel/SwiperCarousel.tsx
+++ b/src/components/WorkCardsCarousel/SwiperCarousel.tsx
@@ -29,6 +29,8 @@ export default function SwiperCarousel({ slidesPerView, centeredSlides, spaceBet
 			centeredSlides={centeredSlides}
 			slidesPerView={slidesPerView}
 			spaceBetween={spaceBetween}
+			speed={1400}
+			grabCursor={true}
 		>
 			{works.map((work) => (
 				<SwiperSlide key={work.slug} className="swiper-slide">

--- a/src/components/WorkCardsCarousel/swiper.style.css
+++ b/src/components/WorkCardsCarousel/swiper.style.css
@@ -20,3 +20,17 @@
 	justify-content: center;
 	align-items: center;
 }
+
+/* Symmetric ease-in-out so slides accelerate gently from rest, glide
+   through the middle, and decelerate softly into place — no abrupt
+   start, no hard stop. Pair with a long `speed` on the Swiper for a
+   continuous-feeling motion. */
+.swiper-wrapper {
+	transition-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.swiper-wrapper {
+		transition: none !important;
+	}
+}


### PR DESCRIPTION
Lengthen slide transition to 1400ms, swap timing function to symmetric easeInOutCubic on .swiper-wrapper so autoplay steps accelerate/decelerate gently. Add grabCursor; prefers-reduced-motion still disables the transition.