### PR TITLE
feat(tweets): scheduled GitHub Action to keep tweets fresh

### DIFF
--- a/.github/workflows/refresh-tweets.yml
+++ b/.github/workflows/refresh-tweets.yml
@@ -1,0 +1,52 @@
+name: Refresh tweets
+
+# Re-fetches the tweet metadata listed in scripts/tweets-config.json,
+# updates src/data/tweets.json, and pushes if the file changed. The push
+# triggers the standard Vercel deploy from main.
+#
+# To add new tweets to the activity widget, append URLs to
+# scripts/tweets-config.json — this workflow will keep their text/dates
+# fresh on every run.
+
+on:
+  schedule:
+    # Daily at 12:00 UTC (~09:00 ART).
+    - cron: '0 12 * * *'
+  # Manual trigger from the Actions tab for ad-hoc refreshes.
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci --no-audit --no-fund
+
+      - name: Fetch tweets
+        run: npm run fetch-tweets
+
+      - name: Commit and push if changed
+        run: |
+          if [ -n "$(git status --porcelain src/data/tweets.json)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add src/data/tweets.json
+            git commit -m "chore(data): refresh tweets via scheduled workflow"
+            git push origin main
+            echo "Pushed updated tweets.json — Vercel will redeploy."
+          else
+            echo "tweets.json is already up to date."
+          fi

--- a/scripts/fetch-tweets.mjs
+++ b/scripts/fetch-tweets.mjs
@@ -36,9 +36,29 @@ function extractTweetId(url) {
 	return match[1];
 }
 
+function decodeHtmlEntities(text) {
+	return text
+		.replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+		.replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+		.replace(/&quot;/g, '"')
+		.replace(/&apos;/g, "'")
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&nbsp;/g, ' ')
+		.replace(/&amp;/g, '&');
+}
+
 function parseTweetHtml(html) {
 	const pMatch = html.match(/<p[^>]*>([\s\S]*?)<\/p>/);
-	const rawText = pMatch ? pMatch[1].replace(/<[^>]+>/g, '').trim() : '';
+	const rawText = pMatch
+		? decodeHtmlEntities(
+			pMatch[1]
+				// Preserve paragraph breaks Twitter encodes as <br>.
+				.replace(/<br\s*\/?>/gi, '\n')
+				.replace(/<[^>]+>/g, '')
+				.trim()
+		)
+		: '';
 
 	const dateMatches = html.match(/<a[^>]*>([A-Za-z]+ \d{1,2}, \d{4})<\/a>/g);
 	let date = '';
@@ -63,7 +83,10 @@ function cleanTweetText(text) {
 	return text
 		.replace(/https?:\/\/t\.co\/\w+/g, '')
 		.replace(/pic\.twitter\.com\/\w+/g, '')
-		.replace(/\s{2,}/g, ' ')
+		// Collapse only horizontal whitespace runs so paragraph breaks survive.
+		.replace(/[ \t]{2,}/g, ' ')
+		// Cap consecutive newlines at two (one blank line max).
+		.replace(/\n{3,}/g, '\n\n')
 		.trim();
 }
 

--- a/scripts/tweets-config.json
+++ b/scripts/tweets-config.json
@@ -1,5 +1,12 @@
 [
-	"https://x.com/fachebits/status/2026005468682883396",
-	"https://x.com/fachebits/status/2024330494028968232",
-	"https://x.com/fachebits/status/2023261074343047652"
+	"https://x.com/fachebits/status/2049231490127475047",
+	"https://x.com/fachebits/status/2049156587760095249",
+	"https://x.com/fachebits/status/2048847675827663104",
+	"https://x.com/fachebits/status/2048037422718411150",
+	"https://x.com/fachebits/status/2047646740371636667",
+	"https://x.com/fachebits/status/2047455641552220248",
+	"https://x.com/fachebits/status/2047305306275811790",
+	"https://x.com/fachebits/status/2046899995983446271",
+	"https://x.com/fachebits/status/2046897093122396302",
+	"https://x.com/fachebits/status/2046891872338022639"
 ]

--- a/src/components/Widget/TwitterWidget/index.tsx
+++ b/src/components/Widget/TwitterWidget/index.tsx
@@ -68,7 +68,7 @@ export default function TwitterWidget() {
 	const { isDarkMode } = useTheme();
 	const profileImg = isDarkMode ? profileDark : profileLight;
 
-	const visibleTweets = tweets.slice(0, 3);
+	const visibleTweets = tweets;
 	const lastActivity = visibleTweets[0]
 		? formatRelativeTime(t, visibleTweets[0].date)
 		: null;
@@ -100,7 +100,7 @@ export default function TwitterWidget() {
 		>
 			<StyledWidgetHandle>{TWITTER_HANDLE}</StyledWidgetHandle>
 
-			<StyledTweetList>
+			<StyledTweetList data-lenis-prevent>
 				{visibleTweets.map((tweet, i) => (
 					<StyledTweetItem
 						key={tweet.id}

--- a/src/components/Widget/TwitterWidget/styled.tsx
+++ b/src/components/Widget/TwitterWidget/styled.tsx
@@ -6,7 +6,25 @@ export const StyledTweetList = styled.div`
 	flex-direction: column;
 	gap: var(--6);
 	width: 100%;
-	flex: 1;
+	/* ~3 visible items at default sizing — anything beyond scrolls without
+	   pushing the widget taller. */
+	max-height: 160px;
+	min-height: 0;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+	scrollbar-width: thin;
+	scrollbar-color: var(--glass-border-start) transparent;
+
+	&::-webkit-scrollbar {
+		width: 4px;
+	}
+	&::-webkit-scrollbar-track {
+		background: transparent;
+	}
+	&::-webkit-scrollbar-thumb {
+		background-color: var(--glass-border-start);
+		border-radius: var(--radius-pill);
+	}
 `;
 
 export const StyledTweetText = styled.p`

--- a/src/data/tweets.json
+++ b/src/data/tweets.json
@@ -22,7 +22,7 @@
 	},
 	{
 		"id": "2048037422718411150",
-		"text": "Buen arranque de la hackathon, a shippear 🚀\n\n@v0 @crecimientoar\n\n#ZeroToAgent",
+		"text": "Buen arranque de la hackathon, a shippear 🚀@v0 @crecimientoar #ZeroToAgent",
 		"date": "2026-04-25",
 		"authorName": "Fache 🧉",
 		"url": "https://twitter.com/fachebits/status/2048037422718411150"


### PR DESCRIPTION
## Summary

Production was stuck on 3 old tweets because Vercel's build always runs `fetch-tweets` first and overwrites `src/data/tweets.json` based on `scripts/tweets-config.json` — which had only 3 URLs. Manual edits to `tweets.json` got clobbered on every deploy.

**Fixes**
1. `scripts/tweets-config.json` now lists the full 10 URLs being rendered, so build-time regeneration produces the matching set.
2. New `.github/workflows/refresh-tweets.yml` runs daily at 12:00 UTC (and on demand via workflow_dispatch). Runs `npm run fetch-tweets` on main, commits `src/data/tweets.json` if changed, pushes — triggering a Vercel redeploy.
3. Parser bugs in `fetch-tweets.mjs`:
   - Decode HTML entities (e.g. `&#39;` → `'`).
   - Convert `<br>` to `\n` and stop collapsing newlines, preserving paragraph breaks when oEmbed exposes them.

Also includes the still-uncommitted Twitter scroll changes from previous turns (`tweets.slice(0,3)` → all tweets, `max-height: 160px` + scroll, `data-lenis-prevent` to bypass Lenis).

## Test plan
- [ ] PR build runs `fetch-tweets` and produces `tweets.json` matching the config.
- [ ] After merge to main, manually trigger workflow via Actions tab → Run workflow. Confirms the action runs end-to-end.
- [ ] Adding a new URL to `tweets-config.json` and pushing → next scheduled run picks it up; or local `npm run fetch-tweets` produces it.
- [ ] Twitter widget still scrolls, footer stays accurate.