### PR TITLE
feat(analytics): Speed Insights + custom event tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "gsap": "^3.13.0",
         "i18next": "^25.8.13",
         "lenis": "^1.0.45",
@@ -2014,6 +2015,44 @@
         "@remix-run/react": {
           "optional": true
         },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
         "@sveltejs/kit": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@gsap/react": "^2.1.2",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "gsap": "^3.13.0",
     "i18next": "^25.8.13",
     "lenis": "^1.0.45",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import ReactLenis from 'lenis/react';
 
 //! Analytics
 import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/react';
 
 //* Context
 import { ThemeProvider } from './context/ThemeContext';
@@ -82,6 +83,7 @@ function App() {
 		<ErrorBoundary>
 			<RouterProvider router={router} />
 			<Analytics />
+			<SpeedInsights />
 		</ErrorBoundary>
 	);
 }

--- a/src/components/Containers/Footer.tsx
+++ b/src/components/Containers/Footer.tsx
@@ -8,6 +8,9 @@ import Text from "../Text";
 import ThemeSwitcher from "../ThemeSwitcher";
 import LanguageSwitcher from "../LanguageSwitcher";
 
+//? Analytics
+import { trackEvent } from "../../lib/analytics";
+
 const StyledFooter = styled.footer`
 	position: relative;
 	width: calc(100% - 24px);
@@ -54,7 +57,7 @@ function Footer({ ref, ...props }: React.ComponentPropsWithRef<'footer'>) {
 						i18nKey="footerCta"
 						ns="common"
 						components={{
-							cta: <a href="https://cal.com/tobiasfacello"><u /></a>,
+							cta: <a href="https://cal.com/tobiasfacello" onClick={() => trackEvent({ name: 'booking_cta_click' })}><u /></a>,
 						}}
 					/>
 				</Text>

--- a/src/components/ProjectCard/index.tsx
+++ b/src/components/ProjectCard/index.tsx
@@ -15,6 +15,9 @@ import { useTechPillDegradation } from '../../hooks/usePillDegradation';
 //? Types
 import { ProjectCardProps } from '../../types';
 
+//? Analytics
+import { trackEvent } from '../../lib/analytics';
+
 const techIconMap: Record<string, React.ComponentType<React.SVGProps<SVGSVGElement>>> = {
 	'Next.js': iconRegistry.nextJs,
 	'TypeScript': iconRegistry.typescript,
@@ -42,6 +45,7 @@ function ProjectCard(props: ProjectCardProps) {
 			href={props.url}
 			target="_blank"
 			rel="noopener noreferrer"
+			onClick={() => trackEvent({ name: 'project_click', data: { slug: props.slug } })}
 		>
 			<Container
 				ref={contentRef as React.Ref<HTMLDivElement>}

--- a/src/components/SocialButton/index.tsx
+++ b/src/components/SocialButton/index.tsx
@@ -3,6 +3,9 @@ import { StyledSocialButton, StyledSocialIcon } from "./styled";
 import { SocialButtonProps } from "../../types";
 import Tooltip from "../Tooltip";
 
+//? Analytics
+import { trackEvent } from "../../lib/analytics";
+
 export default memo(function SocialButton(props: SocialButtonProps) {
 	return (
 		<Tooltip text={props.alt || ''} position={props.tooltipPosition}>
@@ -12,6 +15,7 @@ export default memo(function SocialButton(props: SocialButtonProps) {
 				target="_blank"
 				rel="noopener noreferrer"
 				aria-label={`${props.alt} (opens in new tab)`}
+				onClick={() => trackEvent({ name: 'social_click', data: { platform: (props.alt ?? '').toLowerCase(), source: 'profile' } })}
 			>
 				<StyledSocialIcon aria-hidden="true">
 					<props.Icon />

--- a/src/components/Widget/WidgetBase/index.tsx
+++ b/src/components/Widget/WidgetBase/index.tsx
@@ -6,6 +6,9 @@ import Text from '../../Text';
 import Button from '../../Button';
 import WidgetSkeleton from '../../Skeleton/WidgetSkeleton';
 
+//? Analytics
+import { trackEvent } from '../../../lib/analytics';
+
 //* Styled
 import {
 	StyledWidgetCard,
@@ -49,6 +52,7 @@ export default function WidgetBase(props: WidgetBaseProps) {
 						title={t('activity.viewProfile')}
 						url={props.profileUrl}
 						p={['4', '8', '4', '8']}
+						onClick={() => trackEvent({ name: 'social_click', data: { platform: props.platformName.toLowerCase(), source: 'widget' } })}
 					/>
 				)}
 			</StyledWidgetHeader>

--- a/src/components/WorkCard/index.tsx
+++ b/src/components/WorkCard/index.tsx
@@ -16,6 +16,8 @@ import { iconRegistry } from '../Icon';
 import { WorkCardProps } from '../../types';
 //? Data
 import { hasDetailPage } from '../../data/works';
+//? Analytics
+import { trackEvent } from '../../lib/analytics';
 
 const HourglassIcon = () => (
 	<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -43,17 +45,20 @@ function WorkCard(props: WorkCardProps) {
 
 	const handleCardClick = useCallback(() => {
 		if (isDetail) {
+			trackEvent({ name: 'work_click', data: { slug: props.slug, action: 'detail' } });
 			navigate(`/work/${props.slug}`, { viewTransition: true });
 		}
 	}, [isDetail, navigate, props.slug]);
 
 	const handleButtonClick = useCallback((e: React.MouseEvent) => {
 		e.stopPropagation();
+		trackEvent({ name: 'work_click', data: { slug: props.slug, action: 'site' } });
 		window.open(props.url, '_blank', 'noopener,noreferrer');
-	}, [props.url]);
+	}, [props.slug, props.url]);
 
 	const handleDocClick = useCallback((e: React.MouseEvent) => {
 		e.stopPropagation();
+		trackEvent({ name: 'work_click', data: { slug: props.slug, action: 'docs' } });
 		navigate(`/work/${props.slug}`, { viewTransition: true });
 	}, [navigate, props.slug]);
 
@@ -193,6 +198,7 @@ function WorkCard(props: WorkCardProps) {
 			href={props.url}
 			target="_blank"
 			rel="noopener noreferrer"
+			onClick={() => trackEvent({ name: 'work_click', data: { slug: props.slug, action: 'site' } })}
 			$p={props.p}
 			$m={props.m}
 		>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,13 @@
+import { track } from '@vercel/analytics';
+
+//? Types
+import { AnalyticsEvent } from '../types';
+
+export function trackEvent(event: AnalyticsEvent): void {
+	if ('data' in event) {
+		track(event.name, event.data);
+		return;
+	}
+
+	track(event.name);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -198,3 +198,9 @@ export type BlogCardProps = {
 	status: BlogCardStatus;
 	url?: string;
 };
+
+export type AnalyticsEvent =
+	| { name: 'booking_cta_click' }
+	| { name: 'social_click'; data: { platform: string; source: 'profile' | 'widget' } }
+	| { name: 'project_click'; data: { slug: string } }
+	| { name: 'work_click'; data: { slug: string; action: 'detail' | 'site' | 'docs' } };


### PR DESCRIPTION
## Contexto

Vercel Web Analytics (PR #52) solo capturaba page views automáticos. Esta PR agrega
Core Web Vitals reales y eventos custom de conversión/interés para el portfolio.

## Cambios

- **Speed Insights**: `@vercel/speed-insights` + `<SpeedInsights />` junto a `<Analytics />` en `App.tsx`.
- **Helper tipado**: `src/lib/analytics.ts` con `trackEvent()` + unión `AnalyticsEvent` en `src/types/index.ts`.
- **Eventos cableados** (reusando componentes/handlers existentes):
  - `booking_cta_click` — link cal.com del Footer
  - `social_click` — `SocialButton` (profile) y `WidgetBase` (widget)
  - `project_click` — `ProjectCard`
  - `work_click` — handlers de `WorkCard` (`detail` / `site` / `docs`)

`package-lock.json`: solo se agregó la entrada de `@vercel/speed-insights` (lockfile mínimo).

## Verificación

- `npm run lint` ✅ (`--max-warnings 0`)
- `npm run build` ✅ (tsc valida el tipado de `AnalyticsEvent`)
- Runtime (agent-browser): confirmados en consola `social_click`, `project_click`, `work_click` (→ `/_vercel/insights/event`) y Speed Insights (→ `/_vercel/speed-insights/vitals`).

## Paso manual pendiente (post-deploy)

Activar **Web Analytics** y **Speed Insights** en el dashboard de Vercel. Sin ese toggle no se recolectan datos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)